### PR TITLE
Add runbook for VMCannotBeEvicted

### DIFF
--- a/runbooks/VMCannotBeEvicted.md
+++ b/runbooks/VMCannotBeEvicted.md
@@ -1,0 +1,22 @@
+# VMCannotBeEvicted
+
+## Meaning
+
+This alert fires when the eviction strategy of a VM is set to "LiveMigration" but the VM is not migratable.
+
+## Impact
+
+Such a none-migratable VMs block node eviction which can impact operations such as node drain, updates, etc..
+
+## Diagnosis
+
+Check the eviction strategy and the Migratable status of the VMI
+
+- `kubectl get vmis  -o yaml `  
+   Search for evictionStrategy field. For example "evictionStrategy: LiveMigrate"
+
+- `kubectl get vmis  -o wide`  
+  Look at the "LIVE-MIGRATABLE" column of the output
+ 
+## Mitigation
+Change the VM to be migratable or set the evictionStrategy to shutdown

--- a/runbooks/VMCannotBeEvicted.md
+++ b/runbooks/VMCannotBeEvicted.md
@@ -16,7 +16,7 @@ Check the eviction strategy and the Migratable status of the VMI
    Search for evictionStrategy field. For example "evictionStrategy: LiveMigrate"
 
 - `kubectl get vmis  -o wide`  
-  Look at the "LIVE-MIGRATABLE" column of the output. In case the status is "Flase" you can inspect the VMI
+  Look at the "LIVE-MIGRATABLE" column of the output. In case the status is "False" you can inspect the VMI
   to understand what is the reason that the VM can't be migrated.  
   
   Run `kubectl get vmis  -o yaml`  and inspect the `conditions` section under the VMI status. For example:
@@ -35,4 +35,4 @@ Check the eviction strategy and the Migratable status of the VMI
 ## Mitigation
 In order to resolve the situation and alert you can either
 1. Set the evictionStrategy to shutdown
-1. Inspect the reason that prohibit the VM to be live migrated (as described above) and see whether this can be changed. For example: changing disk type, network configuration etc.
+1. Inspect the reasons that prohibit the VM to be live migrated (as described above) and see whether this can be changed. For example: changing disk type, network configuration etc.

--- a/runbooks/VMCannotBeEvicted.md
+++ b/runbooks/VMCannotBeEvicted.md
@@ -6,7 +6,7 @@ This alert fires when the eviction strategy of a VM is set to "LiveMigration" bu
 
 ## Impact
 
-Such a none-migratable VMs block node eviction which can impact operations such as node drain, updates, etc..
+Such non-migratable VMs block node eviction which can impact operations such as node drain, updates, etc..
 
 ## Diagnosis
 
@@ -16,7 +16,23 @@ Check the eviction strategy and the Migratable status of the VMI
    Search for evictionStrategy field. For example "evictionStrategy: LiveMigrate"
 
 - `kubectl get vmis  -o wide`  
-  Look at the "LIVE-MIGRATABLE" column of the output
+  Look at the "LIVE-MIGRATABLE" column of the output. In case the status is "Flase" you can inspect the VMI
+  to understand what is the reason that the VM can't be migrated.  
+  
+  Run `kubectl get vmis  -o yaml`  and inspect the `conditions` section under the VMI status. For example:
+    
+```
+  status:
+    conditions:
+    - lastProbeTime: null
+      lastTransitionTime: null
+      message: cannot migrate VMI which does not use masquerade to connect to the pod network
+      reason: InterfaceNotLiveMigratable
+      status: "False"
+      type: LiveMigratable
+```
  
 ## Mitigation
-Change the VM to be migratable or set the evictionStrategy to shutdown
+In order to resolve the situation and alert you can either
+1. Set the evictionStrategy to shutdown
+1. Inspect the reason that prohibit the VM to be live migrated (as described above) and see whether this can be changed. For example: changing disk type, network configuration etc.

--- a/runbooks/VMCannotBeEvicted.md
+++ b/runbooks/VMCannotBeEvicted.md
@@ -6,7 +6,7 @@ This alert fires when the eviction strategy of a VM is set to "LiveMigration" bu
 
 ## Impact
 
-Such non-migratable VMs block node eviction which can impact operations such as node drain, updates, etc..
+Non-migratable VMs block node eviction. This can impact operations such as node drain, updates, etc..
 
 ## Diagnosis
 


### PR DESCRIPTION
Signed-off-by: Ezra Silvera <ezra@il.ibm.com>

VMCannotBeEvicted is generated when the eviction strategy of a VM is set to "Live Migration" but the VM is not migratable. 
The PR to generate the Prometheus metrics and alert is in  https://github.com/kubevirt/kubevirt/pull/5392