### PR TITLE
Make VirtAPIDown environment agnostic

### DIFF
--- a/runbooks/VirtAPIDown.md
+++ b/runbooks/VirtAPIDown.md
@@ -10,16 +10,22 @@ Without KubeVirt API servers, no API call around KubeVirt entities can be made a
 
 ## Diagnosis
 
-Check to see if there are any running virt-api pods
+- Set the environment variable `NAMESPACE`
+	```
+	export NAMESPACE="$(kubectl get kubevirt -A -o custom-columns="":.metadata.namespace)"
+	```
 
-`kubectl -n kubevirt get pods -l kubevirt.io=virt-api`
+- Check to see if there are any running virt-api pods.
+	```
+	kubectl -n $NAMESPACE get pods -l kubevirt.io=virt-api
+	```
 
 ## Mitigation
 
 There can be several reasons for virt-api pods to be down, identify the root cause and fix it.
 
 - Check the status of the virt-api deployment to find out more information. The following commands will provide the associated events and show if there are any issues with pulling an image, crashing pod, etc. 
-	- `kubectl -n kubevirt get deploy virt-api -o yaml`
-    - `kubectl -n kubevirt describe deploy virt-api`
+	- `kubectl -n $NAMESPACE get deploy virt-api -o yaml`
+    - `kubectl -n $NAMESPACE describe deploy virt-api`
 - Check if there are issues with the nodes. For example, if they are in a NotReady state.
 	- `kubectl get nodes`


### PR DESCRIPTION
Signed-off-by: Erkan Erol <eerol@redhat.com>

The namespace of Kubevirt is different in different environments.
- `kubevirt`  in https://kubevirt.io/user-guide/operations/installation/
- `kubevirt-hyperconverged` in hco repo
- `openshift-cnv` in OpenShift Virtualization

This PR adds another step to get the namespace from the cluster and to use it in the diagnosis&mitigation. 
