### PR TITLE
Added new labels required for alerts

### DIFF
--- a/monitoring-guidelines.md
+++ b/monitoring-guidelines.md
@@ -42,12 +42,15 @@ When creating a KubeVirt alert rule, please see the following :
 
 1. Use [recording rules](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/#recording-rules) when doing calculations.
 2. Create an alert runbook at [kubevirt/monitoring repository](https://github.com/kubevirt/monitoring/tree/main/docs/runbooks).
-3. Alert rule must include `runbook_url` with the link to your runbook from step #2.
-4. Alert rule must include `severity`. One of: `critical`, `warning`, `info`.
+3. Alert rules must include:  
+   3.1. `runbook_url` label, with the link to your runbook from step #2.  
+   3.2. `severity` label. One of: `critical`, `warning`, `info`.
 
-    NOTE:
-     - Critical alerts - When the service is down and you loss critical functionality, an action is required immediately.
-     - Warning alerts - When an alert require user intervention. A more serious issue may develop if this is not resolved soon.
-     - Info alerts - When a minor problem has been detected. It should be reviewed and not ignored.
+       NOTE:
+       - Critical alerts - When the service is down and you loss critical functionality, an action is required immediately.
+       - Warning alerts - When an alert require user intervention. A more serious issue may develop if this is not resolved soon.
+       - Info alerts - When a minor problem has been detected. It should be reviewed and not ignored.
+   3.3. `kubernetes_operator_part_of` label with `kubevirt` value.  
+   3.4. `kubernetes_operator_component` label with the value of the sub operator name.
 
-5. Alert `message` must be verbose, since it is being propagated to the [metrics.md](https://github.com/kubevirt/kubevirt/blob/main/docs/metrics.md) file, when running `make-generate`.
+4. Alert `message` must be verbose, since it is being propagated to the [metrics.md](https://github.com/kubevirt/kubevirt/blob/main/docs/metrics.md) file, when running `make-generate`.


### PR DESCRIPTION
Added `kubernetes_operator_part_of` and
`kubernetes_operator_component` lables that
are required for all new alerts.

Signed-off-by: Shirly Radco <sradco@redhat.com>