### PR TITLE
Fixed format of DS links

### DIFF
--- a/docs/runbooks/CDIDataVolumeUnusualRestartCount.md
+++ b/docs/runbooks/CDIDataVolumeUnusualRestartCount.md
@@ -32,7 +32,7 @@ Data volumes are responsible for importing and creating a virtual machine disk o
 
 Delete the data volume, resolve the issue, and create a new data volume.
 
-<!--DS: If you cannot resolve the issue, log in to the [Customer Portal](https://access.redhat.com) and open a support case, attaching the artifacts gathered during the Diagnosis procedure.-->
+<!--DS: If you cannot resolve the issue, log in to the link:https://access.redhat.com[Customer Portal] and open a support case, attaching the artifacts gathered during the Diagnosis procedure.-->
 
 <!--USstart-->
 If you cannot resolve the issue, see the following resources:

--- a/docs/runbooks/KubeMacPoolDown.md
+++ b/docs/runbooks/KubeMacPoolDown.md
@@ -32,7 +32,7 @@ If `KubeMacPool` is down, `VirtualMachine` objects cannot be created.
 
 ## Mitigation
 
-<!--DS: If you cannot resolve the issue, log in to the [Customer Portal](https://access.redhat.com) and open a support case, attaching the artifacts gathered during the Diagnosis procedure.-->
+<!--DS: If you cannot resolve the issue, log in to the link:https://access.redhat.com[Customer Portal] and open a support case, attaching the artifacts gathered during the Diagnosis procedure.-->
 
 <!--USstart-->
 If you cannot resolve the issue, see the following resources:

--- a/docs/runbooks/KubeVirtVMIExcessiveMigrations.md
+++ b/docs/runbooks/KubeVirtVMIExcessiveMigrations.md
@@ -88,7 +88,7 @@ Ensure that the worker nodes have sufficient resources (CPU, memory, disk) to ru
  
 If the problem persists, try to identify the root cause and resolve the issue. 
 
-<!--DS: If you cannot resolve the issue, log in to the [Customer Portal](https://access.redhat.com) and open a support case, attaching the artifacts gathered during the Diagnosis procedure.-->
+<!--DS: If you cannot resolve the issue, log in to the link:https://access.redhat.com[Customer Portal] and open a support case, attaching the artifacts gathered during the Diagnosis procedure.-->
 
 <!--USstart-->
 If you cannot resolve the issue, see the following resources:

--- a/docs/runbooks/OrphanedVirtualMachineInstances.md
+++ b/docs/runbooks/OrphanedVirtualMachineInstances.md
@@ -54,7 +54,7 @@ If the `virt-handler` daemon set is healthy:
 
 There are other possible causes for a `virt-handler` pod being removed from a node, such as changes to the node's taints and tolerations or to a pod's scheduling rules.
 
-<!--DS: If you cannot resolve the issue, log in to the [Customer Portal](https://access.redhat.com) and open a support case, attaching the artifacts gathered during the Diagnosis procedure.-->
+<!--DS: If you cannot resolve the issue, log in to the link:https://access.redhat.com[Customer Portal] and open a support case, attaching the artifacts gathered during the Diagnosis procedure.-->
 
 <!--USstart-->
 See [How Daemon Pods are scheduled](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#how-daemon-pods-are-scheduled) for more information.

--- a/docs/runbooks/SSPFailingToReconcile.md
+++ b/docs/runbooks/SSPFailingToReconcile.md
@@ -40,7 +40,7 @@ Dependent components might not be deployed. Changes in the components might not 
  
 ## Mitigation
 
-<!--DS: If you cannot resolve the issue, log in to the [Customer Portal](https://access.redhat.com) and open a support case, attaching the artifacts gathered during the Diagnosis procedure.-->
+<!--DS: If you cannot resolve the issue, log in to the link:https://access.redhat.com[Customer Portal] and open a support case, attaching the artifacts gathered during the Diagnosis procedure.-->
 
 <!--USstart-->
 If you cannot resolve the issue, see the following resources:

--- a/docs/runbooks/SSPOperatorDown.md
+++ b/docs/runbooks/SSPOperatorDown.md
@@ -32,7 +32,7 @@ Dependent components might not be deployed. Changes in the components might not 
 
 ## Mitigation
 
-<!--DS: If you cannot resolve the issue, log in to the [Customer Portal](https://access.redhat.com) and open a support case, attaching the artifacts gathered during the Diagnosis procedure.-->
+<!--DS: If you cannot resolve the issue, log in to the link:https://access.redhat.com[Customer Portal] and open a support case, attaching the artifacts gathered during the Diagnosis procedure.-->
 
 <!--USstart-->
 If you cannot resolve the issue, see the following resources:

--- a/docs/runbooks/SSPTemplateValidatorDown.md
+++ b/docs/runbooks/SSPTemplateValidatorDown.md
@@ -32,7 +32,7 @@ VMs are not validated against their templates. As a result, VMs might be created
 
 ## Mitigation
 
-<!--DS: If you cannot resolve the issue, log in to the [Customer Portal](https://access.redhat.com) and open a support case, attaching the artifacts gathered during the Diagnosis procedure.-->
+<!--DS: If you cannot resolve the issue, log in to the link:https://access.redhat.com[Customer Portal] and open a support case, attaching the artifacts gathered during the Diagnosis procedure.-->
 
 <!--USstart-->
 If you cannot resolve the issue, see the following resources:

--- a/docs/runbooks/VirtAPIDown.md
+++ b/docs/runbooks/VirtAPIDown.md
@@ -36,7 +36,7 @@ KubeVirt objects cannot send API calls.
 
 Identify the root cause and resolve it.
 
-<!--DS: If you cannot resolve the issue, log in to the [Customer Portal](https://access.redhat.com) and open a support case, attaching the artifacts gathered during the Diagnosis procedure.-->
+<!--DS: If you cannot resolve the issue, log in to the link:https://access.redhat.com[Customer Portal] and open a support case, attaching the artifacts gathered during the Diagnosis procedure.-->
 
 <!--USstart-->
 If you cannot resolve the issue, see the following resources:


### PR DESCRIPTION
Changed format of downstream CP link to Asciidoc because Kramdoc does not convert links in comments.

Signed-off-by: Avital Pinnick <apinnick@redhat.com>