### PR TITLE
Rename KubeVirtDeprecatedAPIRequested to singular

### DIFF
--- a/docs/runbooks/KubeVirtDeprecatedAPIRequested.md
+++ b/docs/runbooks/KubeVirtDeprecatedAPIRequested.md
@@ -1,4 +1,4 @@
-# KubeVirtDeprecatedAPIsRequested
+# KubeVirtDeprecatedAPIRequested
 <!-- Edited by fmatouschek, May 2023-->
 
 ## Meaning

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -26,7 +26,7 @@ Examples of runbooks can be found in this repository and in the [prometheus-oper
 * [KubeMacPoolDuplicateMacsFound](KubeMacPoolDuplicateMacsFound.md)
 * [KubeVirtComponentExceedsRequestedCPU](KubeVirtComponentExceedsRequestedCPU.md)
 * [KubeVirtComponentExceedsRequestedMemory](KubeVirtComponentExceedsRequestedMemory.md)
-* [KubeVirtDeprecatedAPIsRequested](KubeVirtDeprecatedAPIsRequested.md)
+* [KubeVirtDeprecatedAPIRequested](KubeVirtDeprecatedAPIRequested.md)
 * [KubeVirtNoAvailableNodesToRunVMs](KubeVirtNoAvailableNodesToRunVMs.md)
 * [KubeVirtVMIExcessiveMigrations](KubeVirtVMIExcessiveMigrations.md)
 * [KubevirtHyperconvergedClusterOperatorCRModification](KubevirtHyperconvergedClusterOperatorCRModification.md)


### PR DESCRIPTION
Renaming KubeVirtDeprecatedAPIsRequested to KubeVirtDeprecatedAPIRequested avoids confusion about plural/singular use.

See https://github.com/kubevirt/monitoring/pull/172#discussion_r1219942486