### PR TITLE
Add metrics parser to metricFamily for prom-metrics-linter

### DIFF
--- a/test/metrics/prom-metrics-linter/metrics-parser/go.mod
+++ b/test/metrics/prom-metrics-linter/metrics-parser/go.mod
@@ -1,0 +1,7 @@
+module github.com/kubevirt/monitoring/test/metrics/prom-metrics-linter/metrics-parser
+
+go 1.20
+
+require github.com/prometheus/client_model v0.4.0
+
+require google.golang.org/protobuf v1.30.0 // indirect

--- a/test/metrics/prom-metrics-linter/metrics-parser/go.sum
+++ b/test/metrics/prom-metrics-linter/metrics-parser/go.sum
@@ -1,0 +1,10 @@
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/prometheus/client_model v0.4.0 h1:5lQXD3cAg1OXBf4Wq03gTrXHeaV0TQvGfUooCfx1yqY=
+github.com/prometheus/client_model v0.4.0/go.mod h1:oMQmHW1/JoDwqLtg57MGgP/Fb1CJEYF2imWWhWtMkYU=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
+google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=

--- a/test/metrics/prom-metrics-linter/metrics-parser/metrics_parser.go
+++ b/test/metrics/prom-metrics-linter/metrics-parser/metrics_parser.go
@@ -1,0 +1,52 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package metrics_parser
+
+import (
+	dto "github.com/prometheus/client_model/go"
+)
+
+// Metric represents a Prometheus metric
+type Metric struct {
+	Name string `json:"name,omitempty"`
+	Help string `json:"help,omitempty"`
+	Type string `json:"type,omitempty"`
+}
+
+// Set the correct metric type for creating MetricFamily
+func CreateMetricFamily(m Metric) *dto.MetricFamily {
+	metricType := dto.MetricType_UNTYPED
+
+	switch m.Type {
+	case "Counter":
+		metricType = dto.MetricType_COUNTER
+	case "Gauge":
+		metricType = dto.MetricType_GAUGE
+	case "Histogram":
+		metricType = dto.MetricType_HISTOGRAM
+	case "Summary":
+		metricType = dto.MetricType_SUMMARY
+	}
+
+	return &dto.MetricFamily{
+		Name: &m.Name,
+		Help: &m.Help,
+		Type: &metricType,
+	}
+}


### PR DESCRIPTION
In order to maintain general methods used to send metrics to prom-metrics-linter, we want to move as much code as possible to this monitoring repo.  