### PR TITLE
Copy KubemacpoolDown runbook to a correct file name

### DIFF
--- a/docs/runbooks/KubemacpoolDown.md
+++ b/docs/runbooks/KubemacpoolDown.md
@@ -1,7 +1,5 @@
-# KubeMacPoolDown
+# KubemacpoolDown
 <!-- Edited by apinnick, Oct. 2022-->
-
-**Note:** Starting from 4.14, this runbook was replaced by [KubemacpoolDown runbook](http://kubevirt.io/monitoring/runbooks/KubemacpoolDown.html).
 
 ## Meaning
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -29,6 +29,7 @@ Examples of runbooks can be found in this repository and in the [prometheus-oper
 * [KubeVirtDeprecatedAPIRequested](KubeVirtDeprecatedAPIRequested.md)
 * [KubeVirtNoAvailableNodesToRunVMs](KubeVirtNoAvailableNodesToRunVMs.md)
 * [KubeVirtVMIExcessiveMigrations](KubeVirtVMIExcessiveMigrations.md)
+* [KubemacpoolDown](KubemacpoolDown.md)
 * [KubevirtHyperconvergedClusterOperatorCRModification](KubevirtHyperconvergedClusterOperatorCRModification.md)
 * [KubevirtHyperconvergedClusterOperatorInstallationNotCompletedAlert](KubevirtHyperconvergedClusterOperatorInstallationNotCompletedAlert.md)
 * [KubevirtHyperconvergedClusterOperatorNMOInUseAlert](KubevirtHyperconvergedClusterOperatorNMOInUseAlert.md)


### PR DESCRIPTION
Currently, [KubemacpoolDown alert](https://github.com/kubevirt/cluster-network-addons-operator/blob/main/data/monitoring/prom-rule.yaml#L57) has a runbook with the name `KubeMacPoolDown`. This PR copies this runbook to a new runbook which is named correctly.