### PR TITLE
Update the error burst alert runbooks

### DIFF
--- a/docs/runbooks/VirtApiRESTErrorsBurst.md
+++ b/docs/runbooks/VirtApiRESTErrorsBurst.md
@@ -1,9 +1,8 @@
 # VirtApiRESTErrorsBurst
-<!-- Edited by Jiří Herrmann, 8 Nov 2022 -->
 
 ## Meaning
 
-More than 80% of REST calls have failed in the `virt-api` pods in the last 5 minutes.
+For the last 10 minutes or longer, over 80% of the REST calls made to `virt-api` pods have failed.
 
 ## Impact
 

--- a/docs/runbooks/VirtControllerRESTErrorsBurst.md
+++ b/docs/runbooks/VirtControllerRESTErrorsBurst.md
@@ -1,9 +1,8 @@
 # VirtControllerRESTErrorsBurst
-<!-- Edited by Jiří Herrmann, 8 Nov 2022 -->
 
 ## Meaning
 
-More than 80% of REST calls in `virt-controller` pods failed in the last 5 minutes.
+For the last 10 minutes or longer, over 80% of the REST calls made to `virt-controller` pods have failed.
 
 The `virt-controller` has likely fully lost the connection to the API server.
 

--- a/docs/runbooks/VirtHandlerRESTErrorsBurst.md
+++ b/docs/runbooks/VirtHandlerRESTErrorsBurst.md
@@ -1,9 +1,10 @@
 # VirtHandlerRESTErrorsBurst
-<!-- Edited by Jiří Herrmann, 9 Nov 2022 -->
 
 ## Meaning
 
-More than 80% of REST calls failed in `virt-handler` in the last 5 minutes. This alert usually indicates that the `virt-handler` pods cannot connect to the API server.
+For the last 10 minutes or longer, over 80% of the REST calls made to `virt-handler` pods have failed.
+
+This alert usually indicates that the `virt-handler` pods cannot connect to the API server.
 
 This error is frequently caused by one of the following problems:
 

--- a/docs/runbooks/VirtOperatorRESTErrorsBurst.md
+++ b/docs/runbooks/VirtOperatorRESTErrorsBurst.md
@@ -1,9 +1,10 @@
 # VirtOperatorRESTErrorsBurst
-<!-- Edited by Jiří Herrmann, 8 Nov 2022 -->
 
 ## Meaning
 
-This alert fires when more than 80% of the REST calls in the `virt-operator` pods failed in the last 5 minutes. This usually indicates that the `virt-operator` pods cannot connect to the API server. 
+For the last 10 minutes or longer, over 80% of the REST calls made to `virt-operator` pods have failed.
+
+This usually indicates that the `virt-operator` pods cannot connect to the API server.
 
 This error is frequently caused by one of the following problems:
 


### PR DESCRIPTION
Updated the alert runbooks related to error burst alerts, to indicate the burst in ongoing for the last 5 minutes and perhaps event more.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Fixes: https://issues.redhat.com/browse/CNV-38540

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
