### PR TITLE
Update kubevirt-top-consumers.json

### DIFF
--- a/dashboards/openshift/kubevirt-top-consumers.json
+++ b/dashboards/openshift/kubevirt-top-consumers.json
@@ -978,7 +978,7 @@
       ],
       "targets": [
         {
-          "expr": "sort_desc(topk(5, sum(rate(kubevirt_vmi_vcpu_wait_seconds[$__range])) by (namespace, name)))>0",
+          "expr": "sort_desc(topk(5, sum(rate(kubevirt_vmi_vcpu_wait_seconds_total[$__range])) by (namespace, name)))>0",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -1143,7 +1143,7 @@
       ],
       "targets": [
         {
-          "expr": "sort_desc(topk(5, sum(avg_over_time(kubevirt_vmi_memory_swap_in_traffic_bytes_total[$__range]) + avg_over_time(kubevirt_vmi_memory_swap_out_traffic_bytes_total[$__range])) by (namespace, name)))>0",
+          "expr": "sort_desc(topk(5, sum(avg_over_time(kubevirt_vmi_memory_swap_in_traffic_bytes[$__range]) + avg_over_time(kubevirt_vmi_memory_swap_out_traffic_bytes[$__range])) by (namespace, name)))>0",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -1761,7 +1761,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sort_desc(sum(irate(kubevirt_vmi_vcpu_wait_seconds{}[$__rate_interval])) by (name, namespace))>0",
+          "expr": "sort_desc(sum(irate(kubevirt_vmi_vcpu_wait_seconds_total{}[$__rate_interval])) by (name, namespace))>0",
           "format": "time_series",
           "interval": "",
           "legendFormat": "{{name}} / {{namespace}}",
@@ -1860,7 +1860,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sort_desc(sum(avg_over_time(kubevirt_vmi_memory_swap_in_traffic_bytes_total{}[$__rate_interval]) + avg_over_time(kubevirt_vmi_memory_swap_out_traffic_bytes_total{}[$__rate_interval])) by (name, namespace))>0",
+          "expr": "sort_desc(sum(avg_over_time(kubevirt_vmi_memory_swap_in_traffic_bytes{}[$__rate_interval]) + avg_over_time(kubevirt_vmi_memory_swap_out_traffic_bytes{}[$__rate_interval])) by (name, namespace))>0",
           "format": "time_series",
           "instant": false,
           "interval": "",


### PR DESCRIPTION
Update kubevirt-top-consumers dashboard.
Replace:
kubevirt_vmi_vcpu_wait_seconds -> kubevirt_vmi_vcpu_wait_seconds_total kubevirt_vmi_memory_swap_in_traffic_bytes_total -> kubevirt_vmi_memory_swap_in_traffic_bytes

Since the vCPU Wait by Virtual Machines and Memory Swap Traffic by Virtual Machines graphs are also empty on CNV engineering due to the changes in: https://github.com/kubevirt/kubevirt/pull/9821

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://issues.redhat.com/browse/OCPBUGS-33077

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
