### PR TITLE
metrics name linter: Remove timestamp_seconds suffix restriction

### DIFF
--- a/test/metrics/prom-metrics-linter/custom_linter_rules.go
+++ b/test/metrics/prom-metrics-linter/custom_linter_rules.go
@@ -43,14 +43,6 @@ func CustomLinterRules(problems []promlint.Problem, mf *dto.MetricFamily, operat
 		})
 	}
 
-	// Check "_timestamp_seconds" suffix for non-counter metrics
-	if *mf.Type != dto.MetricType_COUNTER && strings.HasSuffix(*mf.Name, "_timestamp_seconds") {
-		problems = append(problems, promlint.Problem{
-			Metric: *mf.Name,
-			Text:   "non-counter metric should not have \"_timestamp_seconds\" suffix",
-		})
-	}
-
 	// If promlint fails on a "total" suffix, check also for "_timestamp_seconds" suffix. If it exists, do not fail
 	var newProblems []promlint.Problem
 	for _, problem := range problems {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR removes the linter's `timestamp_seconds` suffix restriction for non-counter metrics, as gauge metrics should be allowed to use it. Timestamp metrics are usually not cumulative, and should be of gauge type. 
For example,  in https://kubernetes.io/docs/reference/instrumentation/metrics/#list-of-stable-kubernetes-metrics all the `timestamp_seconds` metrics are gauges.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
