### PR TITLE
Update KubevirtVmHighMemoryUsage Playbook

### DIFF
--- a/docs/runbooks/KubevirtVmHighMemoryUsage.md
+++ b/docs/runbooks/KubevirtVmHighMemoryUsage.md
@@ -3,12 +3,12 @@
 ## Meaning
 
 This alert fires when a container hosting a virtual machine (VM) has less than
-20 MB free memory.
+50 Mi free memory before reaching its requested memory.
 
 ## Impact
 
-The virtual machine running inside the container is terminated by the runtime
-if the container's memory limit is exceeded.
+The virtual machine running inside the container is at risk of eviction by the
+runtime if the container's memory request is exceeded.
 
 ## Diagnosis
 
@@ -27,7 +27,7 @@ if the container's memory limit is exceeded.
 
 ## Mitigation
 
-Increase the memory limit in the `VirtualMachine` specification as in the
+Increase the memory request in the `VirtualMachine` specification as in the
 following example:
 
 ```yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The playbook for KubevirtVmHighMemoryUsage is now out of date with the alert itself.

The threshold for the alert got changed from 20MB to 50MB in https://github.com/kubevirt/kubevirt/pull/9834

The units got updated in the alert description in https://github.com/kubevirt/kubevirt/pull/9073

The alert changed from using pod limits to request in https://github.com/kubevirt/kubevirt/pull/7204

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update KubevirtVmHighMemoryUsage playbook wording
```
