### PR TITLE
Enable runbook-sync-downstream automation workflow 

### DIFF
--- a/.github/workflows/runbook_sync_downstream.yaml
+++ b/.github/workflows/runbook_sync_downstream.yaml
@@ -1,0 +1,23 @@
+name: Run runbook-sync-downstream
+
+on:
+  schedule:
+    - cron:  '30 4 * * *'
+
+  workflow_dispatch:
+
+jobs:
+  runbook_sync_downstream:
+    name: Run runbook-sync-downstream
+    if: (github.repository == 'kubevirt/monitoring')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.22'
+
+      - name: Run runbook-sync-downstream
+        run: DRY_RUN=false GITHUB_TOKEN=${{ secrets.OPENSHIFT_MERGE_BOT_TOKEN }} make runbook-sync-downstream

--- a/.github/workflows/runbook_sync_downstream.yaml
+++ b/.github/workflows/runbook_sync_downstream.yaml
@@ -20,4 +20,4 @@ jobs:
           go-version: '1.22'
 
       - name: Run runbook-sync-downstream
-        run: DRY_RUN=false GITHUB_TOKEN=${{ secrets.OPENSHIFT_MERGE_BOT_TOKEN }} make runbook-sync-downstream
+        run: DRY_RUN=false GITHUB_TOKEN=${{ secrets.HCO_BOT_TOKEN }} make runbook-sync-downstream

--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,11 @@ monitoringlinter-test: monitoringlinter-build
 lint-markdown:
 	echo "Linting markdown files"
 	podman run -v ${PWD}:/workdir:Z docker.io/davidanson/markdownlint-cli2:v0.13.0 "/workdir/docs/*runbooks/*.md"
+
+.PHONY: build-runbook-sync-downstream
+build-runbook-sync-downstream:
+	cd tools/runbook-sync-downstream && go build -ldflags="-s -w" -o _out/runbook-sync-downstream .
+
+.PHONY: runbook-sync-downstream
+runbook-sync-downstream: build-runbook-sync-downstream
+	tools/runbook-sync-downstream/_out/runbook-sync-downstream


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Enable automation to sync runbook updates

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://issues.redhat.com/browse/CNV-41925

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
