### PR TITLE
Improve CDI alert runbooks

### DIFF
--- a/docs/runbooks/CDIDataImportCronOutdated.md
+++ b/docs/runbooks/CDIDataImportCronOutdated.md
@@ -15,8 +15,8 @@ For golden images, _latest_ refers to the latest operating system of the
 distribution. For other disk images, _latest_ refers to the latest hash of the
 image that is available.
 
-In case there is no default (Kubernetes or KubeVirt) storage class, and the
-DataImportCron import PVC is pending for one, the alert is suppressed as the
+In case there is no default (Kubernetes or virtualization) storage class, and the
+`DataImportCron` import PVC is `Pending` for one, the alert is suppressed as the
 root cause is already alerted by CDINoDefaultStorageClass.
 
 ## Impact
@@ -27,20 +27,22 @@ VMs might fail to start because no boot source is available for cloning.
 
 ## Diagnosis
 
-1. Check the cluster for a default (Kubernetes and/or virtualization) storage class:
-
+1. Check the cluster for a default Kubernetes storage class:
    ```bash
    $ kubectl get sc -o jsonpath='{.items[?(.metadata.annotations.storageclass\.kubernetes\.io\/is-default-class=="true")].metadata.name}'
+   ```
 
+   Check the cluster for a default virtualization storage class:
+   ```bash
    $ kubectl get sc -o jsonpath='{.items[?(.metadata.annotations.storageclass\.kubevirt\.io\/is-default-virt-class=="true")].metadata.name}'
    ```
 
    The output displays the default (Kubernetes and/or virtualization) storage
    class. You must either set a default storage class on the cluster, or ask for
    a specific storage class in the `DataImportCron` specification, in order for
-   the `DataImportCron` to poll and import golden images. If the effective
+   the `DataImportCron` to poll and import golden images. If the default
    storage class does not exist, the created import DataVolume and PVC will be
-   in Pending phase.
+   in `Pending` phase.
 
 2. Obtain the `DataImportCrons` which are not up-to-date:
 

--- a/docs/runbooks/CDIDefaultStorageClassDegraded.md
+++ b/docs/runbooks/CDIDefaultStorageClassDegraded.md
@@ -22,21 +22,22 @@ If the default storage class does not support ReadWriteMany, virtual machines
 
 ## Diagnosis
 
-1. Get the default KubeVirt storage class by running the following command:
+1. Get the default virtualization storage class by running the following
+command:
 
    ```bash
    $ export CDI_DEFAULT_VIRT_SC="$(kubectl get sc -o jsonpath='{.items[?(.metadata.annotations.storageclass\.kubevirt\.io\/is-default-virt-class=="true")].metadata.name}')"
    ```
 
-2. If a default KubeVirt storage class exists, check that it supports
+2. If a default virtualization storage class exists, check that it supports
 ReadWriteMany by running the following command:
 
    ```bash
    $ kubectl get storageprofile $CDI_DEFAULT_VIRT_SC -o jsonpath='{.status.claimPropertySets}' | grep ReadWriteMany
    ```
 
-3. If there is no default KubeVirt storage class, get the default Kubernetes
-storage class by running the following command:
+3. If there is no default virtualization storage class, get the default
+Kubernetes storage class by running the following command:
 
    ```bash
    $ export CDI_DEFAULT_K8S_SC="$(kubectl get sc -o jsonpath='{.items[?(.metadata.annotations.storageclass\.kubernetes\.io\/is-default-class=="true")].metadata.name}')"
@@ -56,7 +57,7 @@ for details about smart clone prerequisites.
 
 ## Mitigation
 
-Ensure that you have a default storage class, either Kubernetes or KubeVirt, and
+Ensure that you have a default (Kubernetes or virtualization) storage class, and
 that the default storage class supports smart cloning and ReadWriteMany.
 
 <!--USstart-->

--- a/docs/runbooks/CDIDefaultStorageClassDegraded.md
+++ b/docs/runbooks/CDIDefaultStorageClassDegraded.md
@@ -2,11 +2,15 @@
 
 ## Meaning
 
-This alert fires when there is no default storage class that supports smart
-cloning (CSI or snapshot-based) or the ReadWriteMany access mode.
+This alert fires when there is/are default (Kubernetes and/or virtualization)
+storage class(es), but none of them supports both smart cloning (CSI or snapshot
+based) and ReadWriteMany access mode.
 
 A default virtualization storage class has precedence over a default Kubernetes
 storage class for creating a VirtualMachine disk image.
+
+In case of single-node OpenShift, the alert is suppressed if there is a default
+storage class that supports smart cloning, but not ReadWriteMany.
 
 ## Impact
 
@@ -21,28 +25,28 @@ If the default storage class does not support ReadWriteMany, virtual machines
 1. Get the default KubeVirt storage class by running the following command:
 
    ```bash
-   $ export CDI_DEFAULT_VIRT_SC="$(kubectl get sc -o json | jq -r '.items[].metadata|select(.annotations."storageclass.kubevirt.io/is-default-virt-class"=="true")|.name')"
+   $ export CDI_DEFAULT_VIRT_SC="$(kubectl get sc -o jsonpath='{.items[?(.metadata.annotations.storageclass\.kubevirt\.io\/is-default-virt-class=="true")].metadata.name}')"
    ```
 
 2. If a default KubeVirt storage class exists, check that it supports
 ReadWriteMany by running the following command:
 
    ```bash
-   $ kubectl get storageprofile $CDI_DEFAULT_VIRT_SC -o json | jq '.status.claimPropertySets'| grep ReadWriteMany
+   $ kubectl get storageprofile $CDI_DEFAULT_VIRT_SC -o jsonpath='{.status.claimPropertySets}' | grep ReadWriteMany
    ```
 
 3. If there is no default KubeVirt storage class, get the default Kubernetes
 storage class by running the following command:
 
    ```bash
-   $ export CDI_DEFAULT_K8S_SC="$(kubectl get sc -o json | jq -r '.items[].metadata|select(.annotations."storageclass.kubernetes.io/is-default-class"=="true")|.name')"
+   $ export CDI_DEFAULT_K8S_SC="$(kubectl get sc -o jsonpath='{.items[?(.metadata.annotations.storageclass\.kubernetes\.io\/is-default-class=="true")].metadata.name}')"
    ```
 
 4. If a default Kubernetes storage class exists, check that it supports
 ReadWriteMany by running the following command:
 
    ```bash
-   $ kubectl get storageprofile $CDI_DEFAULT_K8S_SC -o json | jq '.status.claimPropertySets'| grep ReadWriteMany
+   $ kubectl get storageprofile $CDI_DEFAULT_VIRT_SC -o jsonpath='{.status.claimPropertySets}' | grep ReadWriteMany
    ```
 
 <!--USstart-->

--- a/docs/runbooks/CDIDefaultStorageClassDegraded.md
+++ b/docs/runbooks/CDIDefaultStorageClassDegraded.md
@@ -9,8 +9,8 @@ based) and ReadWriteMany access mode.
 A default virtualization storage class has precedence over a default Kubernetes
 storage class for creating a VirtualMachine disk image.
 
-In case of single-node OpenShift, the alert is suppressed if there is a default
-storage class that supports smart cloning, but not ReadWriteMany.
+<!--DS: In case of single-node OpenShift, the alert is suppressed if there is a default
+storage class that supports smart cloning, but not ReadWriteMany.-->
 
 ## Impact
 

--- a/docs/runbooks/CDIMultipleDefaultVirtStorageClasses.md
+++ b/docs/runbooks/CDIMultipleDefaultVirtStorageClasses.md
@@ -19,7 +19,7 @@ Obtain a list of default virtualization storage classes by running the following
 command:
 
 ```bash
-$ kubectl get sc -o json | jq '.items[].metadata|select(.annotations."storageclass.kubevirt.io/is-default-virt-class"=="true")|.name'
+$ kubectl get sc -o jsonpath='{.items[?(.metadata.annotations.storageclass\.kubevirt\.io\/is-default-virt-class=="true")].metadata.name}'
 ```
 
 ## Mitigation

--- a/docs/runbooks/CDINoDefaultStorageClass.md
+++ b/docs/runbooks/CDINoDefaultStorageClass.md
@@ -19,13 +19,13 @@ does not have a specified storage class remains in a "pending" state.
 command:
 
   ```bash
-  $ kubectl get sc -o json | jq '.items[].metadata|select(.annotations."storageclass.kubernetes.io/is-default-class"=="true")|.name'
+  $ kubectl get sc -o jsonpath='{.items[?(.metadata.annotations.storageclass\.kubernetes\.io\/is-default-class=="true")].metadata.name}'
   ```
 
 2. Check for a default KubeVirt storage class by running the following command:
 
   ```bash
-  $ kubectl get sc -o json | jq '.items[].metadata|select(.annotations."storageclass.kubevirt.io/is-default-virt-class"=="true")|.name'
+  $ kubectl get sc -o jsonpath='{.items[?(.metadata.annotations.storageclass\.kubevirt\.io\/is-default-virt-class=="true")].metadata.name}'
   ```
 
 ## Mitigation

--- a/docs/runbooks/CDINoDefaultStorageClass.md
+++ b/docs/runbooks/CDINoDefaultStorageClass.md
@@ -2,16 +2,17 @@
 
 ## Meaning
 
-This alert fires when there is no default (Kubernetes or KubeVirt) storage
-class, and a data volume is pending for one.
+This alert fires when there is no default (Kubernetes or virtualization) storage
+class, and a data volume is `Pending` for one.
 
-A default KubeVirt storage class has precedence over a default Kubernetes
+A default virtualization storage class has precedence over a default Kubernetes
 storage class for creating a VirtualMachine disk image.
 
 ## Impact
 
-If there is no default Kubernetes or KubeVirt storage class, a data volume that
-does not have a specified storage class remains in a "pending" state.
+If there is no default (Kubernetes or virtualization) storage class, a data
+volume that does not have a specified storage class remains in a `Pending`
+phase.
 
 ## Diagnosis
 
@@ -22,7 +23,8 @@ command:
   $ kubectl get sc -o jsonpath='{.items[?(.metadata.annotations.storageclass\.kubernetes\.io\/is-default-class=="true")].metadata.name}'
   ```
 
-2. Check for a default KubeVirt storage class by running the following command:
+2. Check for a default virtualization storage class by running the following
+command:
 
   ```bash
   $ kubectl get sc -o jsonpath='{.items[?(.metadata.annotations.storageclass\.kubevirt\.io\/is-default-virt-class=="true")].metadata.name}'
@@ -30,9 +32,9 @@ command:
 
 ## Mitigation
 
-Create a default storage class for either Kubernetes or KubeVirt or for both.
+Create a default (Kubernetes and/or virtualization) storage class.
 
-A default KubeVirt storage class has precedence over a default Kubernetes
+A default virtualization storage class has precedence over a default Kubernetes
 storage class for creating a virtual machine disk image.
 
 * Create a default Kubernetes storage class by running the following command:
@@ -41,7 +43,8 @@ storage class for creating a virtual machine disk image.
   $ kubectl patch storageclass <storage-class-name> -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
   ```
 
-* Create a default KubeVirt storage class by running the following command:
+* Create a default virtualization storage class by running the following
+command:
 
   ```bash
   $ kubectl patch storageclass <storage-class-name> -p '{"metadata": {"annotations":{"storageclass.kubevirt.io/is-default-virt-class":"true"}}}'


### PR DESCRIPTION
**What this PR does / why we need it**:

- Improve and cleanup the runbooks.
- Use `kubectl` `jsonpath` instead of `jq`.
- Align all references to default `virtualization` storage class instead of `KubeVirt`.

**Which issue(s) this PR fixes**:
jira-ticket: https://issues.redhat.com/browse/CNV-37427

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
Improve CDI alert runbooks
```