### PR TITLE
Improve CDI alert runbooks clarity

### DIFF
--- a/docs/runbooks/CDIDataImportCronOutdated.md
+++ b/docs/runbooks/CDIDataImportCronOutdated.md
@@ -15,9 +15,9 @@ For golden images, _latest_ refers to the latest operating system of the
 distribution. For other disk images, _latest_ refers to the latest hash of the
 image that is available.
 
-In case there is no default (Kubernetes or virtualization) storage class, and the
-`DataImportCron` import PVC is `Pending` for one, the alert is suppressed as the
-root cause is already alerted by CDINoDefaultStorageClass.
+**Note:** If the status of a `DataImportCron` PVC is `Pending` because there is no
+default storage class, the `CDIDataImportCronOutdated` alert is suppressed and the
+`CDINoDefaultStorageClass` alert is triggered.
 
 ## Impact
 
@@ -44,14 +44,14 @@ VMs might fail to start because no boot source is available for cloning.
    storage class does not exist, the created import DataVolume and PVC will be
    in `Pending` phase.
 
-2. Obtain the `DataImportCrons` which are not up-to-date:
+2. List the `DataImportCron` objects that are not up-to-date:
 
    ```bash
    $ kubectl get dataimportcron -A -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="UpToDate")].status}{"\t"}{.metadata.namespace}{"/"}{.metadata.name}{"\n"}{end}' | grep False
    ```
 
 3. If a default storage class is not defined on the cluster, check the
-`DataImportCron` specification for optional storage class:
+`DataImportCron` specification for `DataVolume` template storage class:
 
    ```bash
    $ kubectl -n <namespace> get dataimportcron <dataimportcron> -o jsonpath='{.spec.template.spec.storage.storageClassName}{"\n"}'

--- a/docs/runbooks/CDIDataImportCronOutdated.md
+++ b/docs/runbooks/CDIDataImportCronOutdated.md
@@ -51,7 +51,7 @@ VMs might fail to start because no boot source is available for cloning.
    ```
 
 3. If a default storage class is not defined on the cluster, check the
-`DataImportCron` specification for `DataVolume` template storage class:
+`DataImportCron` specification for a `DataVolume` template storage class:
 
    ```bash
    $ kubectl -n <namespace> get dataimportcron <dataimportcron> -o jsonpath='{.spec.template.spec.storage.storageClassName}{"\n"}'

--- a/docs/runbooks/CDIDefaultStorageClassDegraded.md
+++ b/docs/runbooks/CDIDefaultStorageClassDegraded.md
@@ -2,9 +2,9 @@
 
 ## Meaning
 
-This alert fires when there is/are default (Kubernetes and/or virtualization)
-storage class(es), but none of them supports both smart cloning (CSI or snapshot
-based) and ReadWriteMany access mode.
+This alert fires if the default storage class does not support smart cloning
+(CSI or snapshot-based) or the ReadWriteMany access mode. The alert does not
+fire if at least one default storage class supports these features.
 
 A default virtualization storage class has precedence over a default Kubernetes
 storage class for creating a VirtualMachine disk image.

--- a/docs/runbooks/CDINoDefaultStorageClass.md
+++ b/docs/runbooks/CDINoDefaultStorageClass.md
@@ -2,17 +2,17 @@
 
 ## Meaning
 
-This alert fires when there is no default (Kubernetes or virtualization) storage
-class, and a data volume is `Pending` for one.
+This alert fires when a data volume is `Pending` because there is no default
+storage class.
 
 A default virtualization storage class has precedence over a default Kubernetes
 storage class for creating a VirtualMachine disk image.
 
 ## Impact
 
-If there is no default (Kubernetes or virtualization) storage class, a data
-volume that does not have a specified storage class remains in a `Pending`
-phase.
+If there is no default Kubernetes storage class and no default virtualization
+storage class, a data volume that does not have a specified storage class
+remains in a `Pending` phase.
 
 ## Diagnosis
 
@@ -32,7 +32,7 @@ command:
 
 ## Mitigation
 
-Create a default (Kubernetes and/or virtualization) storage class.
+Create a default storage class for Kubernetes, virtualization, or both.
 
 A default virtualization storage class has precedence over a default Kubernetes
 storage class for creating a virtual machine disk image.


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow-up to #253 fixing @ousleyp comments.

**Which issue(s) this PR fixes**:
jira-ticket: https://issues.redhat.com/browse/CNV-37427

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
