### PR TITLE
Add HCOMisconfiguredDescheduler runbook

### DIFF
--- a/docs/runbooks/HCOMisconfiguredDescheduler.md
+++ b/docs/runbooks/HCOMisconfiguredDescheduler.md
@@ -1,0 +1,73 @@
+# HCOMisconfiguredDescheduler
+
+## Meaning
+
+A Descheduler is a Kubernetes application that causes the control plane to
+re-arrange the workloads in a better way.
+
+The descheduler uses the Kubernetes eviction API to evict pods, and receives
+feedback from `kube-api` whether the eviction request was granted or not.
+On the other side, in order to keep VM live and trigger live-migration,
+KubeVirt handles eviction requests in a custom way and unfortunately
+a live migration takes time.
+So from the descheduler's point of view, `virt-launcher` pods fail to be
+evicted, but they actually migrating to another node in background.
+So the way KubeVirt handles eviction requests causes the descheduler to
+make wrong decisions and take wrong actions that could destabilize the cluster.
+
+
+To correctly handle the special case of `VM` pod evicted triggering a live
+migration to another node, the `Kube Descheduler Operator` introduced
+a `profileCustomizations` named `devEnableEvictionsInBackground`
+which is currently considered an `alpha` feature
+on `Kube Descheduler Operator` side.
+
+## Impact
+
+Using the descheduler operator for KubeVirt VMs without the
+`devEnableEvictionsInBackground` profile customization can lead to
+unstable or oscillatory behavior, undermining cluster stability.
+
+## Diagnosis
+
+1. Check the CR for `Kube Descheduler Operator`:
+
+   ```bash
+   $ kubectl get -n openshift-kube-descheduler-operator KubeDescheduler cluster -o yaml
+   ```
+
+looking for:
+
+   ```yaml
+   spec:
+      profileCustomizations:
+         devEnableEvictionsInBackground: true
+   ```
+
+If not there, the `Kube Descheduler Operator` is not correctly configured
+to work alongside KubeVirt.
+
+## Mitigation
+
+Set:
+   ```yaml
+   spec:
+      profileCustomizations:
+         devEnableEvictionsInBackground: true
+   ```
+on the CR for the `Kube Descheduler Operator` or
+remove the `Kube Descheduler Operator`.
+
+Please notice that `EvictionsInBackground` is an alpha feature,
+and it's subject to change and currently provided as an
+experimental feature.
+
+<!--DS: If you cannot resolve the issue, log in to the
+link:https://access.redhat.com[Customer Portal] and open a support case,
+attaching the artifacts gathered during the diagnosis procedure.-->
+<!--USstart-->
+If you cannot resolve the issue, see the following resources:
+
+- [OKD Help](https://okd.io/docs/community/help)
+- [#virtualization Slack channel](https://kubernetes.slack.com/channels/virtualization)
+<!--USend-->


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a runbook for `HCOMisconfiguredDescheduler`

A [Descheduler](https://github.com/kubernetes-sigs/descheduler) is a Kubernetes application that causes the control plane to re-arrange the workloads in a better way.
It operates every pre-defined period and goes back to sleep after it had performed its job.

The descheduler uses the Kubernetes [eviction API](https://kubernetes.io/docs/concepts/scheduling-eviction/api-eviction/) to evict pods, and receives feedback from `kube-api` whether the eviction request was granted or not.
On the other side, in order to keep VM live and trigger live-migration, KubeVirt handles eviction requests in a custom way and unfortunately a live migration takes time.
So from the descheduler's point of view, `virt-launcher` pods fail to be evicted, but they actually migrating to another node in background.
The descheduler notes the failure to evict the `virt-launcher` pod and keeps trying to evict other pods, typically resulting in it attempting to evict substantially all `virt-launcher` pods from the node triggering a migration storm.
In other words, the way KubeVirt handles eviction requests causes the descheduler to make wrong decisions and take wrong actions that could destabilize the cluster.
Using the descheduler operator with the `LowNodeUtilization` strategy results in unstable/oscillatory behavior if the descheduler is used in this way to migrate VMs.
To correctly handle the special case of `VM` pod evicted triggering a live migration to another node, the `Kube Descheduler Operator` introduced a `profileCustomizations` named `devEnableEvictionsInBackground`
which is currently considered an `alpha` [feature](https://github.com/kubernetes-sigs/descheduler/tree/master/keps/1397-evictions-in-background) on `Kube Descheduler Operator` side.
to prevent unexpected behaviours, if the `Kube Descheduler Operator` is installed and configured alongside `HCO`, `HCO` will check its configuration looking for the presence of `devEnableEvictionsInBackground` `profileCustomizations` eventually
suggesting to the cluster admin to fix the configuration of the `Kube Descheduler Operator` via an `alert` and its linked `runbook`.

In order to fix the configuration of the `Kube Descheduler Operator` to be suitable also for the KubeVirt use case,
something like:
```yaml
apiVersion: operator.openshift.io/v1
kind: KubeDescheduler
metadata:
  name: cluster
  namespace: openshift-kube-descheduler-operator
spec:
  profileCustomizations:
    devEnableEvictionsInBackground: true
```
should be merged in its configuration.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://issues.redhat.com/browse/CNV-48734

**Special notes for your reviewer**:
It's a runbook for https://github.com/kubevirt/hyperconverged-cluster-operator/pull/3100

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [X] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add HCOMisconfiguredDescheduler runbook
```
