### PR TITLE
Add OperatorConditionsUnhealthy runbook

### DIFF
--- a/docs/runbooks/OperatorConditionsUnhealthy.md
+++ b/docs/runbooks/OperatorConditionsUnhealthy.md
@@ -1,0 +1,40 @@
+# OperatorConditionsUnhealthy
+
+## Meaning
+
+This alert fires when the and operator conditions or its secondary resources
+are in an error or warning state.
+
+## Impact
+
+Resources maintained by the operator may not be functioning correctly.
+
+## Diagnosis
+
+Check the operator conditions:
+
+```bash
+kubectl get <CR> <CR_OBJECT> -n <namespace> -o jsonpath='{.status.conditions}'
+```
+
+e.g.:
+
+```bash
+kubectl get HyperConverged kubevirt-hyperconverged -n kubevirt -o jsonpath='{.status.conditions}'
+```
+
+## Mitigation
+
+Based on the information obtained during the diagnosis procedure, try to
+identify the root cause within the operator or any of its secondary resources
+and resolve the issue.
+<!--DS: If you cannot resolve the issue, log in to the
+link:https://access.redhat.com[Customer Portal] and open a support case,
+attaching the artifacts gathered during the diagnosis procedure.-->
+
+<!--USstart-->
+If you cannot resolve the issue, see the following resources:
+
+- [OKD Help](https://www.okd.io/help/)
+- [#virtualization Slack channel](https://kubernetes.slack.com/channels/virtualization)
+<!--USend-->


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Runbook for https://github.com/kubevirt/hyperconverged-cluster-operator/pull/3144

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add OperatorConditionsUnhealthy runbook
```
