### PR TITLE
Enhance GitHub Actions workflow for multi-platform builds.

### DIFF
--- a/.github/workflows/prom-metrics-linter.yaml
+++ b/.github/workflows/prom-metrics-linter.yaml
@@ -3,6 +3,9 @@ on:
   release:
     types:
       - published
+env:
+  IMAGE_NAME: quay.io/kubevirt/prom-metrics-linter
+  BUILD_PLATFORMS: linux/amd64,linux/arm64,linux/s390x
 
 jobs:
   build:
@@ -12,14 +15,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.0.0
+
       - name: Login to quay.io
         run: docker login -u="${{ secrets.QUAY_USER }}" -p="${{ secrets.QUAY_PASSWORD }}" quay.io
 
-      - name: Build the Docker image
-        run: |
-          IMAGE_NAME="quay.io/kubevirt/prom-metrics-linter:${GITHUB_REF##*/}"
-          CONTAINER_RUNTIME=docker IMG="${IMAGE_NAME}" make promlinter-build
-          echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
-
-      - name: Push the Docker image
-        run: CONTAINER_RUNTIME=docker IMG="${{ env.IMAGE_NAME }}" make promlinter-push
+      - name: Build and push the Docker image
+        uses: docker/build-push-action@v5.3.0
+        with:
+          context: test/metrics/prom-metrics-linter
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+          file: test/metrics/prom-metrics-linter/Dockerfile
+          platforms: ${{ env.BUILD_PLATFORMS }}

--- a/test/metrics/prom-metrics-linter/Dockerfile
+++ b/test/metrics/prom-metrics-linter/Dockerfile
@@ -1,13 +1,15 @@
-FROM golang:1.20 as build
+FROM --platform=${BUILDPLATFORM} golang:1.20 AS build
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /workspace
 
 COPY . .
 
 RUN go mod tidy && \
-    CGO_ENABLED=0 go build -v -trimpath -ldflags "-s -w" -o /bin/ .
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -v -trimpath -ldflags "-s -w" -o /bin/ .
 
-FROM gcr.io/distroless/base:latest
+FROM --platform=linux/${TARGETARCH} gcr.io/distroless/base:latest
 
 COPY --from=build /bin/prom-metrics-linter .
 


### PR DESCRIPTION
These changes enable building and pushing Docker images for multiple platforms (amd64, arm64, s390x).

**What this PR does / why we need it**:

As of now, only x86 support is available for the prom-metrics-linter image: https://quay.io/repository/kubevirt/prom-metrics-linter?tab=tags&tag=latest.

This PR introduces changes to enable multi-architecture builds for arm64 and s390x, in addition to x86, using GitHub Actions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # #285 

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
