### PR TITLE
Update Dockerfile to use TARGETOS instead of linux.

### DIFF
--- a/test/metrics/prom-metrics-linter/Dockerfile
+++ b/test/metrics/prom-metrics-linter/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 RUN go mod tidy && \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -v -trimpath -ldflags "-s -w" -o /bin/ .
 
-FROM --platform=linux/${TARGETARCH} gcr.io/distroless/base:latest
+FROM --platform=${TARGETOS}/${TARGETARCH} gcr.io/distroless/base:latest
 
 COPY --from=build /bin/prom-metrics-linter .
 


### PR DESCRIPTION
This modification ensures that the image can be built for various operating systems, not just Linux, by utilizing the appropriate platform variables during the build process.



**What this PR does / why we need it**:
This PR updates the Dockerfile to dynamically reference the platform architecture using the ${TARGETOS} and ${TARGETARCH} variables instead of the hardcoded linux platform. This change makes the Dockerfile more flexible and adaptable for building images across different operating systems and architectures

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
