### PR TITLE
Bump golang base image in the Dockerfile, to 1.23

### DIFF
--- a/test/metrics/prom-metrics-linter/Dockerfile
+++ b/test/metrics/prom-metrics-linter/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} golang:1.20 AS build
+FROM --platform=${BUILDPLATFORM} golang:1.23 AS build
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Image build: bump golang to v1.23
```
