### PR TITLE
Add runbooks for GuestVCPUQueueHigh alerts

### DIFF
--- a/docs/runbooks/GuestVCPUQueueHighCritical.md
+++ b/docs/runbooks/GuestVCPUQueueHighCritical.md
@@ -1,0 +1,51 @@
+# GuestVCPUQueueHighCritical
+
+## Meaning
+A VirtualMachineInstance (VMI) reported a
+**guest CPU run‑queue length greater than 20** runnable or
+uninterruptible threads within the last scrape window (120s),
+indicating severe CPU contention.
+
+## Impact
+* Sustained backlog; high latency and throughput degradation are likely.
+* Risk of timeouts, watchdog resets, or I/O amplification.
+
+## Diagnosis
+Follow the below steps with extra focus on:
+* **Duration** – How long is the queue > 20
+* **Host saturation** – if node CPU is also > 90 %, migrate other VMs or mark the
+   node as unschedulable so that no new Pods/VMs are placed thereon it.
+
+1. **Confirm queue length**
+   ```promql
+   kubevirt_vmi_guest_vcpu_queue{namespace="$NS",name="$VM"}
+   ```
+2. **Check host CPU usage**
+   ```promql
+   rate(kubevirt_vmi_cpu_usage_seconds_total{namespace="$NS",name="$VM"}[2m])
+   ```
+3. **Inspect guest processes**
+   `virtctl console <vm>` → `top -H` or `pidstat -u 1`
+4. **Verify vCPU allocation**
+   ```bash
+   oc get vmi $VM -ojsonpath='{.spec.domain.cpu}'
+   ```
+
+## Mitigation
+| Horizon  | Action                                                           |
+|----------|------------------------------------------------------------------|
+| Immediate| **Prioritise**: live-migrate VM; hot-plug vCPUs; stop or throttle hot threads.                                            |
+| Short term| Raise vCPU limit or split workload across additional VMs.       |
+| Long term| Adjust placement rules; add autoscaling tied to run-queue length.|
+
+
+<!--USstart-->
+If you cannot resolve the issue, see the following resources:
+
+- [OKD Help](https://www.okd.io/help/)
+- [#virtualization Slack channel](https://kubernetes.slack.com/channels/virtualization)
+<!--USend-->
+
+<!--DS: If you cannot resolve the issue, log in to the
+[Customer Portal](https://access.redhat.com) and open a support case,
+attaching the artifacts gathered during the diagnosis procedure.-->

--- a/docs/runbooks/GuestVCPUQueueHighWarning.md
+++ b/docs/runbooks/GuestVCPUQueueHighWarning.md
@@ -1,0 +1,47 @@
+# GuestVCPUQueueHighWarning
+
+## Meaning
+A VirtualMachineInstance (VMI) reported a
+**guest CPU run‑queue length greater than 10** runnable or
+uninterruptible threads within the most‑recent scrape window (120s).
+The run‑queue length is derived from `guest_load_1m – vCPU_count`.
+
+## Impact
+* Moderate CPU contention inside the guest;
+  latency may spike but workload still progresses.
+* Early signal that the VM might need additional vCPUs or
+  that a short‑lived process is causing bursts.
+
+## Diagnosis
+1. **Confirm queue length**
+   ```promql
+   kubevirt_vmi_guest_vcpu_queue{namespace="$NS",name="$VM"}
+   ```
+2. **Check host CPU usage**
+   ```promql
+   rate(kubevirt_vmi_cpu_usage_seconds_total{namespace="$NS",name="$VM"}[2m])
+   ```
+3. **Inspect guest processes**
+   `virtctl console <vm>` → `top -H` or `pidstat -u 1`
+4. **Verify vCPU allocation**
+   ```bash
+   oc get vmi $VM -ojsonpath='{.spec.domain.cpu}'
+   ```
+
+## Mitigation
+| Horizon | Action |
+|---------|--------|
+| Immediate | Optionally live‑migrate the VM to a quieter node or throttle noisy processes.   |
+| Short term | Hot‑plug / increase vCPUs; tune application thread pools.                      |
+| Long term  | Implement horizontal scaling (HPA/KEDA, VMReplicaSet); review placement rules. |
+
+<!--USstart-->
+If you cannot resolve the issue, see the following resources:
+
+- [OKD Help](https://www.okd.io/help/)
+- [#virtualization Slack channel](https://kubernetes.slack.com/channels/virtualization)
+<!--USend-->
+
+<!--DS: If you cannot resolve the issue, log in to the
+[Customer Portal](https://access.redhat.com) and open a support case,
+attaching the artifacts gathered during the diagnosis procedure.-->


### PR DESCRIPTION
This PR adds runbooks for GuestVCPUQueueHighWarning and GuestVCPUQueueHighCritical alerts.

Signed-off-by: Shirly Radco <sradco@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
