### PR TITLE
Add runbook for VM Guest memory high alerts

### DIFF
--- a/docs/runbooks/KubeVirtVMGuestMemoryAvailableLow.md
+++ b/docs/runbooks/KubeVirtVMGuestMemoryAvailableLow.md
@@ -1,0 +1,73 @@
+# KubeVirtVMGuestMemoryAvailableLow
+
+## Meaning
+The VM guest OS has very low available memory (<3% headroom) for an
+extended period with no meaningful swap I/O, approaching OOM conditions.
+
+## Impact
+- Very limited memory headroom (risk of imminent OOM)
+- Potential application failures and degraded performance
+
+## Diagnosis
+- Metrics (Prometheus)
+  1) Identify the VMI pod (`vmi_pod` label):
+  ```promql
+  kubevirt_vmi_info{vm="<vm-name>", namespace="<namespace>",
+  phase="running"}
+  ```
+  2) Headroom (usable/available) < 3% sustained:
+  ```promql
+  sum by (name, namespace) (
+    kubevirt_vmi_memory_usable_bytes{
+      name="<vmi_pod>", namespace="<namespace>"
+    }
+  ) /
+  sum by (name, namespace) (
+    kubevirt_vmi_memory_available_bytes{
+      name="<vmi_pod>", namespace="<namespace>"
+    }
+  )
+  ```
+  3) Swap traffic ~0 over 30m (likely no swap):
+  ```promql
+  sum by (name, namespace) (
+    rate(
+      kubevirt_vmi_memory_swap_in_traffic_bytes{
+        name="<vmi_pod>", namespace="<namespace>"
+      }[30m]
+    ) +
+    rate(
+      kubevirt_vmi_memory_swap_out_traffic_bytes{
+        name="<vmi_pod>", namespace="<namespace>"
+      }[30m]
+    )
+  )
+  ```
+  4) Major page faults ~0 over 30m:
+  ```promql
+  sum by (name, namespace) (
+    rate(
+      kubevirt_vmi_memory_pgmajfault_total{
+        name="<vmi_pod>", namespace="<namespace>"
+      }[30m]
+    )
+  )
+  ```
+
+## Mitigation
+- Immediate actions (in guest)
+  - If possible, stop or restart memory-hungry processes to reduce load.
+  - If acceptable, drop caches temporarily.
+  - Configure/enable swap per policy (or validate it is intentionally disabled).
+
+- Increase VM memory (hotplug if supported; otherwise restart may be required)
+
+<!--DS: If you cannot resolve the issue, log in to the
+link:https://access.redhat.com[Customer Portal] and open a support case,
+attaching the artifacts gathered during the diagnosis procedure.-->
+<!--USstart-->
+If you cannot resolve the issue, see the following resources:
+
+- [OKD Help](https://okd.io/docs/community/help/)
+- [#virtualization Slack channel](https://kubernetes.slack.com/channels/virtualization)
+<!--USend-->

--- a/docs/runbooks/KubeVirtVMGuestMemoryPressure.md
+++ b/docs/runbooks/KubeVirtVMGuestMemoryPressure.md
@@ -1,0 +1,75 @@
+# KubeVirtVMGuestMemoryPressure
+
+## Meaning
+The VM guest OS is under sustained memory pressure (low usable memory
+with elevated major page faults and/or swap I/O), risking thrashing,
+swapping, or OOM kills.
+
+## Impact
+- Performance degradation due to page thrashing
+- Increased swap I/O and latency
+- Risk of OOM kills and application instability
+
+## Diagnosis
+- Metrics (Prometheus)
+  1) Identify the VMI pod (`vmi_pod` label):
+  ```promql
+  kubevirt_vmi_info{vm="<vm-name>", namespace="<namespace>",
+  phase="running"}
+  ```
+  2) Headroom (usable/available) < 5% indicates pressure:
+  ```promql
+  sum by (name, namespace) (
+    kubevirt_vmi_memory_usable_bytes{
+      name="<vmi_pod>", namespace="<namespace>"
+    }
+  ) /
+  sum by (name, namespace) (
+    kubevirt_vmi_memory_available_bytes{
+      name="<vmi_pod>", namespace="<namespace>"
+    }
+  )
+  ```
+  3) Major page faults are elevated:
+  ```promql
+  sum by (name, namespace) (
+    rate(
+      kubevirt_vmi_memory_pgmajfault_total{
+        name="<vmi_pod>", namespace="<namespace>"
+      }[5m]
+    )
+  )
+  ```
+  4) Swap traffic is elevated (bytes/s):
+  ```promql
+  sum by (name, namespace) (
+    rate(
+      kubevirt_vmi_memory_swap_in_traffic_bytes{
+        name="<vmi_pod>", namespace="<namespace>"
+      }[5m]
+    ) +
+    rate(
+      kubevirt_vmi_memory_swap_out_traffic_bytes{
+        name="<vmi_pod>", namespace="<namespace>"
+      }[5m]
+    )
+  )
+  ```
+
+## Mitigation
+- Short term (in guest)
+  - If possible, Restart or tune memory-heavy processes; reduce workload.
+  - If acceptable, drop caches temporarily.
+  - Ensure swap is sized/policy-compliant (or disabled if not desired).
+
+- Increase VM memory (hotplug if supported; otherwise restart may be required)
+
+<!--DS: If you cannot resolve the issue, log in to the
+link:https://access.redhat.com[Customer Portal] and open a support case,
+attaching the artifacts gathered during the diagnosis procedure.-->
+<!--USstart-->
+If you cannot resolve the issue, see the following resources:
+
+- [OKD Help](https://okd.io/docs/community/help/)
+- [#virtualization Slack channel](https://kubernetes.slack.com/channels/virtualization)
+<!--USend-->


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add runbook for VM Guest memory high alerts
that will be added in https://github.com/kubevirt/kubevirt/pull/15237

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://issues.redhat.com/browse/CNV-54116

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
