### PR TITLE
Add DeprecatedMachineType runbook

### DIFF
--- a/docs/runbooks/DeprecatedMachineType.md
+++ b/docs/runbooks/DeprecatedMachineType.md
@@ -1,0 +1,62 @@
+# DeprecatedMachineType
+
+## Meaning
+This alert fires when one or more Virtual Machines (VMs)  
+are using machine types that have been marked as deprecated (no  
+longer supported).
+
+## Impact
+
+**Running VMs**
+- Continue running but are using a deprecated machine type.
+- Newer nodes may not support this type, so the next live migration may  
+  fail or get stuck.
+- This can block node maintenance and disrupt high availability.
+
+**Stopped VMs**
+- No immediate issue while stopped.
+- When restarted, they may fail to schedule or get stuck if newer nodes  
+  no longer support the deprecated machine type.
+- This can prevent workloads from coming back online after maintenance  
+  or cluster upgrades.
+
+
+## Diagnosis
+The alert detects VMs using deprecated machine types.
+
+**Identify affected VMs**  
+   Use the alert description to locate VM names, namespaces, and nodes (if running).
+
+**Root Cause:**  
+The VM's `spec.template.spec.domain.machine.type` field is set to a type
+that has been marked as deprecated. This can happen due to:
+
+- VMs created before a machine type deprecation.
+- VM templates not updated after cluster upgrades.
+- Manual VM creation using old machine type references.
+
+## Mitigation
+Update affected VMs to use a supported machine type. You can:
+
+- Edit VM definitions individually by modifying the
+  `spec.template.spec.domain.machine.type` field.
+- Or, for a smoother and cleaner update of multiple VMs, use the
+  `kubevirt-api-lifecycle-automation` tool to transition all deprecated VMs
+  in one operation. This ensures consistent, automated migration and reduces
+  manual errors or downtime during cluster upgrades. See the documentation  
+  for details: [Updating multiple VMs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/virtualization/managing-vms#virt-updating-multiple-vms_virt-edit-vms)
+
+
+**Important:** Plan and apply these updates before performing cluster
+upgrades to avoid VM restart failures or compatibility issues.
+
+<!--DS: If you cannot resolve the issue, log in to the
+link:https://access.redhat.com[Customer Portal] and open a support case,
+attaching the artifacts gathered during the diagnosis procedure.-->
+<!--USstart-->
+If you cannot resolve the issue, see the following resources:
+
+- [OKD Help](https://okd.io/docs/community/help/)
+- [#virtualization Slack channel](https://kubernetes.slack.com/channels/
+  virtualization)
+<!--USend-->


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the `DeprecatedMachineType` runbook to the docs.

[Alert PR](https://github.com/kubevirt/hyperconverged-cluster-operator/pull/3358)

**Which issue(s) this PR fixes** 
Fixes https://issues.redhat.com/browse/CNV-56660

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
none
```