### PR TITLE
Deprecate the RESTErrorsHigh runbooks

### DIFF
--- a/docs/deprecated_runbooks/KubeMacPoolDown.md
+++ b/docs/deprecated_runbooks/KubeMacPoolDown.md
@@ -1,4 +1,4 @@
-# KubeMacPoolDown
+# KubeMacPoolDown [Deprecated]
 
 **Note:** Starting from 4.14, this runbook was replaced by [KubemacpoolDown runbook](http://kubevirt.io/monitoring/runbooks/KubemacpoolDown.html).
 

--- a/docs/deprecated_runbooks/KubeVirtVMStuckInErrorState.md
+++ b/docs/deprecated_runbooks/KubeVirtVMStuckInErrorState.md
@@ -1,4 +1,7 @@
-# KubeVirtVMStuckInErrorState
+# KubeVirtVMStuckInErrorState [Deprecated]
+
+This alert has been deprecated; it does not indicate a genuine issue. If
+triggered, it may be safely ignored and silenced.
 
 ## Meaning
 

--- a/docs/deprecated_runbooks/KubeVirtVMStuckInMigratingState.md
+++ b/docs/deprecated_runbooks/KubeVirtVMStuckInMigratingState.md
@@ -1,4 +1,7 @@
-# KubeVirtVMStuckInMigratingState
+# KubeVirtVMStuckInMigratingState [Deprecated]
+
+This alert has been deprecated; it does not indicate a genuine issue. If
+triggered, it may be safely ignored and silenced.
 
 ## Meaning
 

--- a/docs/deprecated_runbooks/KubeVirtVMStuckInStartingState.md
+++ b/docs/deprecated_runbooks/KubeVirtVMStuckInStartingState.md
@@ -1,4 +1,7 @@
-# KubeVirtVMStuckInStartingState
+# KubeVirtVMStuckInStartingState [Deprecated]
+
+This alert has been deprecated; it does not indicate a genuine issue. If
+triggered, it may be safely ignored and silenced.
 
 ## Meaning
 

--- a/docs/deprecated_runbooks/KubevirtHyperconvergedClusterOperatorNMOInUseAlert.md
+++ b/docs/deprecated_runbooks/KubevirtHyperconvergedClusterOperatorNMOInUseAlert.md
@@ -1,4 +1,7 @@
-# KubevirtHyperconvergedClusterOperatorNMOInUseAlert
+# KubevirtHyperconvergedClusterOperatorNMOInUseAlert [Deprecated]
+
+This alert has been deprecated; it does not indicate a genuine issue. If
+triggered, it may be safely ignored and silenced.
 
 ## Meaning
 

--- a/docs/deprecated_runbooks/OperatorConditionsUnhealthy.md
+++ b/docs/deprecated_runbooks/OperatorConditionsUnhealthy.md
@@ -1,4 +1,7 @@
-# OperatorConditionsUnhealthy
+# OperatorConditionsUnhealthy [Deprecated]
+
+This alert has been deprecated; it does not indicate a genuine issue. If
+triggered, it may be safely ignored and silenced.
 
 ## Meaning
 

--- a/docs/deprecated_runbooks/VirtApiRESTErrorsHigh.md
+++ b/docs/deprecated_runbooks/VirtApiRESTErrorsHigh.md
@@ -1,4 +1,7 @@
-# VirtApiRESTErrorsHigh
+# VirtApiRESTErrorsHigh [Deprecated]
+
+This alert has been deprecated; it does not indicate a genuine issue. If
+triggered, it may be safely ignored and silenced.
 
 ## Meaning
 
@@ -72,3 +75,4 @@ If you cannot resolve the issue, see the following resources:
 - [OKD Help](https://okd.io/docs/community/help/)
 - [#virtualization Slack channel](https://kubernetes.slack.com/channels/virtualization)
 <!--USend-->
+

--- a/docs/deprecated_runbooks/VirtControllerRESTErrorsHigh.md
+++ b/docs/deprecated_runbooks/VirtControllerRESTErrorsHigh.md
@@ -1,4 +1,7 @@
-# VirtControllerRESTErrorsHigh
+# VirtControllerRESTErrorsHigh [Deprecated]
+
+This alert has been deprecated; it does not indicate a genuine issue. If
+triggered, it may be safely ignored and silenced.
 
 ## Meaning
 
@@ -61,3 +64,4 @@ If you cannot resolve the issue, see the following resources:
 - [OKD Help](https://okd.io/docs/community/help/)
 - [#virtualization Slack channel](https://kubernetes.slack.com/channels/virtualization)
 <!--USend-->
+

--- a/docs/deprecated_runbooks/VirtHandlerRESTErrorsHigh.md
+++ b/docs/deprecated_runbooks/VirtHandlerRESTErrorsHigh.md
@@ -1,4 +1,7 @@
-# VirtHandlerRESTErrorsHigh
+# VirtHandlerRESTErrorsHigh [Deprecated]
+
+This alert has been deprecated; it does not indicate a genuine issue. If
+triggered, it may be safely ignored and silenced.
 
 ## Meaning
 
@@ -67,3 +70,4 @@ If you cannot resolve the issue, see the following resources:
 - [OKD Help](https://okd.io/docs/community/help/)
 - [#virtualization Slack channel](https://kubernetes.slack.com/channels/virtualization)
 <!--USend-->
+

--- a/docs/deprecated_runbooks/VirtOperatorRESTErrorsHigh.md
+++ b/docs/deprecated_runbooks/VirtOperatorRESTErrorsHigh.md
@@ -1,4 +1,7 @@
-# VirtOperatorRESTErrorsHigh
+# VirtOperatorRESTErrorsHigh [Deprecated]
+
+This alert has been deprecated; it does not indicate a genuine issue. If
+triggered, it may be safely ignored and silenced.
 
 ## Meaning
 
@@ -67,3 +70,4 @@ If you cannot resolve the issue, see the following resources:
 - [OKD Help](https://okd.io/docs/community/help/)
 - [#virtualization Slack channel](https://kubernetes.slack.com/channels/virtualization)
 <!--USend-->
+

--- a/docs/deprecated_runbooks/VirtualMachineCRCErrors.md
+++ b/docs/deprecated_runbooks/VirtualMachineCRCErrors.md
@@ -1,4 +1,7 @@
-# VirtualMachineCRCErrors
+# VirtualMachineCRCErrors [Deprecated]
+
+This alert has been deprecated; it does not indicate a genuine issue. If
+triggered, it may be safely ignored and silenced.
 
 ## Meaning
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The RESTErrorsHigh alerts were deprecated.

This PR moved the runbooks to the deprecated
alerts runbooks section and add a [Deprecated]
text next to the alert name and text to indicate
this alert can be safley disregarded and silenced.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://issues.redhat.com/browse/CNV-56033

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
