### PR TITLE
Fix pod references in LowVirtControllersCount runbook

### DIFF
--- a/docs/runbooks/LowVirtControllersCount.md
+++ b/docs/runbooks/LowVirtControllersCount.md
@@ -16,34 +16,28 @@ critical for cluster-wide virtualization functionality.
 The responsiveness of KubeVirt might become negatively affected. For example,
 certain requests might be missed.
 
-In addition, if another `virt-launcher` instance terminates unexpectedly,
+In addition, if another `virt-controller` instance terminates unexpectedly,
 KubeVirt might become completely unresponsive.
 
 ## Diagnosis
 
-1. Set the `NAMESPACE` environment variable:
+1. Verify that running `virt-controller` pods are available:
 
    ```bash
-   $ export NAMESPACE="$(kubectl get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ kubectl -n kubevirt get pods -l kubevirt.io=virt-controller
    ```
 
-2. Verify that running `virt-controller` pods are available:
+2. Check the `virt-controller` logs for error messages:
 
    ```bash
-   $ kubectl -n $NAMESPACE get pods -l kubevirt.io=virt-controller
+   $ kubectl -n kubevirt logs <virt-controller>
    ```
 
-3. Check the `virt-launcher` logs for error messages:
-
-   ```bash
-   $ kubectl -n $NAMESPACE logs <virt-launcher>
-   ```
-
-4. Obtain the details of the `virt-launcher` pod to check for status conditions
+3. Obtain the details of the `virt-controller` pod to check for status conditions
 such as unexpected termination or a `NotReady` state.
 
    ```bash
-   $ kubectl -n $NAMESPACE describe pod/<virt-launcher>
+   $ kubectl -n kubevirt describe pod/<virt-controller>
    ```
 
 ## Mitigation


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
