### PR TITLE
Fix wrong deprecated runbook sync

### DIFF
--- a/tools/runbook-sync-downstream/runbook_test.go
+++ b/tools/runbook-sync-downstream/runbook_test.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -33,6 +37,105 @@ var _ = Describe("Runbook", func() {
 
 		It("should replace namespace in 'namespace: kubevirt-hyperconverged' format", func() {
 			Expect(updateRunbookContent).To(ContainSubstring("i'm a resource -> namespace: openshift-cnv"))
+		})
+	})
+
+	Context("Runbook deprecation", func() {
+		var tempDir string
+		var testRunbookPath string
+
+		BeforeEach(func() {
+			var err error
+			tempDir, err = os.MkdirTemp("", "runbook-test-*")
+			Expect(err).ToNot(HaveOccurred())
+
+			runbooksDir := filepath.Join(tempDir, downstreamRunbooksDir)
+			err = os.MkdirAll(runbooksDir, 0755)
+			Expect(err).ToNot(HaveOccurred())
+
+			testRunbookPath = filepath.Join(runbooksDir, "TestRunbook.md")
+		})
+
+		AfterEach(func() {
+			err := os.RemoveAll(tempDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should deprecate a runbook with original content preserved", func() {
+			By("creating a test runbook")
+			originalContent := `# TestRunbook
+
+## Meaning
+
+This is a test runbook with some content.
+
+## Impact
+
+This describes the impact of the alert.
+
+## Diagnosis
+
+How to diagnose the issue.
+
+## Mitigation
+
+How to fix the issue.`
+
+			err := os.WriteFile(testRunbookPath, []byte(originalContent), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("calling the deprecation function")
+			deprecatedRunbook("TestRunbook", tempDir)
+
+			By("reading the updated content")
+			updatedContent, err := os.ReadFile(testRunbookPath)
+			Expect(err).ToNot(HaveOccurred())
+
+			updatedStr := string(updatedContent)
+
+			By("verifying the updated content")
+			Expect(updatedStr).To(ContainSubstring("# TestRunbook [Deprecated]"))
+
+			By("verifying the deprecation notice is added")
+			Expect(updatedStr).To(ContainSubstring("This alert is deprecated. You can safely ignore or silence it."))
+
+			By("verifying original content is preserved (without the original title)")
+			Expect(updatedStr).To(ContainSubstring("## Meaning"))
+			Expect(updatedStr).To(ContainSubstring("This is a test runbook with some content."))
+			Expect(updatedStr).To(ContainSubstring("## Impact"))
+			Expect(updatedStr).To(ContainSubstring("## Diagnosis"))
+			Expect(updatedStr).To(ContainSubstring("## Mitigation"))
+			Expect(updatedStr).To(ContainSubstring("How to fix the issue."))
+		})
+
+		It("should not re-deprecate an already deprecated runbook", func() {
+			By("creating a runbook that's already deprecated")
+			deprecatedContent := `# TestRunbook [Deprecated]
+
+This alert is deprecated. You can safely ignore or silence it.
+
+## Meaning
+
+This is a test runbook with some content.`
+
+			err := os.WriteFile(testRunbookPath, []byte(deprecatedContent), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("calling the deprecation function")
+			deprecatedRunbook("TestRunbook", tempDir)
+
+			By("reading the updated content")
+			updatedContent, err := os.ReadFile(testRunbookPath)
+			Expect(err).ToNot(HaveOccurred())
+
+			updatedStr := string(updatedContent)
+
+			By("verifying the content remains unchanged")
+			Expect(updatedStr).To(Equal(deprecatedContent))
+
+			By("verifying [Deprecated] appears only once")
+			deprecatedCount := strings.Count(updatedStr, "[Deprecated]")
+			Expect(deprecatedCount).To(Equal(1))
 		})
 	})
 })

--- a/tools/runbook-sync-downstream/templates/deprecated_runbook.tmpl
+++ b/tools/runbook-sync-downstream/templates/deprecated_runbook.tmpl
@@ -1,3 +1,5 @@
 # {{ .RunbookName }} [Deprecated]
 
 This alert is deprecated. You can safely ignore or silence it.
+
+{{ .OriginalContent }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
