### PR TITLE
Add GuestFilesystemAlmostOutOfSpace runbook

### DIFF
--- a/docs/runbooks/GuestFilesystemAlmostOutOfSpace.md
+++ b/docs/runbooks/GuestFilesystemAlmostOutOfSpace.md
@@ -1,0 +1,122 @@
+# GuestFilesystemAlmostOutOfSpace
+
+## Meaning
+
+This alert triggers when a file system in a virtual machine (VM) is running out
+of available disk space.
+
+The alert has the following severity levels:
+
+- **Warning**: Triggers when file-system usage is between 85% and 95% for 5 minutes.
+- **Critical**: Triggers when file-system usage exceeds 95%.
+
+The alert provides details about the specific file system (`disk_name`), its
+mount point (`mount_point`), the VMI name, and namespace.
+
+## Impact
+
+When a guest file system runs out of space, the VM may experience:
+
+- Application failures or crashes due to inability to write data
+- System instability or inability to perform updates
+- Potential data loss if applications cannot write to disk
+- Degraded performance as the system struggles with low disk space
+- The VM may become unresponsive or enter a failed state
+
+Critical space exhaustion (>95%) significantly increases the risk of immediate
+application or system failure.
+
+## Diagnosis
+
+1. Check the file-system usage metrics for the VMI:
+
+   ```bash
+   # Get the domain name of the VMI
+   $ kubectl exec -it <pod-name> -n <namespace> -- virsh list
+   ```
+
+   ```bash
+   # Query filesystem info via QEMU Guest Agent
+   $ kubectl exec -it <pod-name> -n <namespace> -- virsh qemu-agent-command <domain-name> '{"execute": "guest-get-fsinfo"}'
+   ```
+
+2. You can also connect to the VMI by using the `virtctl` console to inspect
+disk usage in the guest OS:
+
+   ```bash
+   $ virtctl console <vmi-name> -n <namespace>
+   ```
+
+   In the guest OS, run commands to evaluate file-system usage. For example, in
+   Linux guests:
+
+   ```bash
+   $ df -h
+   $ du -sh /* | sort -h
+   ```
+
+## Mitigation
+
+### Immediate Actions
+
+1. **Free up space in the guest file system**:
+
+   - Remove temporary files, logs, or caches
+   - Clean up old application data or archives
+   - Remove unnecessary packages or applications
+
+2. **Expand the disk size** if the underlying PVC supports volume expansion:
+
+   a. Check if the storage class supports volume expansion:
+
+      ```bash
+      $ kubectl get storageclass <storage-class-name> -o yaml | grep allowVolumeExpansion
+      ```
+
+   b. Modify the PVC to request a larger size:
+
+      ```bash
+      $ kubectl edit pvc <pvc-name> -n <namespace>
+      # Update the spec.resources.requests.storage value to a larger size
+      ```
+
+   c. Restart the VM to apply the changes:
+
+      ```bash
+      $ virtctl restart <vm-name> -n <namespace>
+      ```
+
+      This step causes the disk.img to be resized to match the new PVC size.
+      While this is primarily needed for filesystem volumes, it's recommended
+      to always restart for consistency.
+
+### Long-term Solutions
+
+1. **Set up log rotation and cleanup policies** within guest operating systems.
+
+2. **Use appropriate volume sizes** when provisioning VMs based on expected
+workload requirements.
+
+3. **Consider using dynamic storage provisioning** with StorageClasses that
+support volume expansion.
+
+4. **Implement automated cleanup scripts** or maintenance tasks within VMs to
+manage disk space proactively.
+
+5. **Review and optimize application storage patterns** to minimize unnecessary
+disk usage.
+
+If the issue persists or the file system continues to fill up rapidly after
+cleanup, investigate the root cause such as application bugs, excessive logging,
+or unexpected data growth.
+
+<!--DS: If you cannot resolve the issue, log in to the
+link:https://access.redhat.com[Customer Portal] and open a support case,
+attaching the artifacts gathered during the diagnosis procedure.-->
+<!--USstart-->
+If you cannot resolve the issue, see the following resources:
+
+- [OKD Help](https://okd.io/docs/community/help/)
+- [#virtualization Slack channel](https://kubernetes.slack.com/channels/
+  virtualization)
+<!--USend-->


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add GuestFilesystemAlmostOutOfSpace runbook

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add GuestFilesystemAlmostOutOfSpace runbook
```
