### PR TITLE
Fix metric linter to handle recording rules separately

### DIFF
--- a/test/metrics/prom-metrics-linter/allowlist.json
+++ b/test/metrics/prom-metrics-linter/allowlist.json
@@ -1,0 +1,56 @@
+{
+  "operators": {
+    "kubevirt": [
+      "kubevirt_allocatable_nodes",
+      "kubevirt_api_request_deprecated_total",
+      "kubevirt_memory_delta_from_requested_bytes",
+      "kubevirt_nodes_with_kvm",
+      "kubevirt_number_of_vms",
+      "kubevirt_virt_api_up",
+      "kubevirt_virt_controller_ready",
+      "kubevirt_virt_controller_up",
+      "kubevirt_virt_handler_up",
+      "kubevirt_virt_operator_leading",
+      "kubevirt_virt_operator_ready",
+      "kubevirt_virt_operator_up",
+      "kubevirt_vm_container_memory_request_margin_based_on_rss_bytes",
+      "kubevirt_vm_container_memory_request_margin_based_on_working_set_bytes",
+      "kubevirt_vm_created_total",
+      "kubevirt_vmi_guest_vcpu_queue",
+      "kubevirt_vmi_memory_used_bytes",
+      "kubevirt_vmi_phase_count",
+      "kubevirt_vmi_vcpu_count",
+      "kubevirt_vmsnapshot_disks_restored_from_source",
+      "kubevirt_vmsnapshot_disks_restored_from_source_bytes",
+      "kubevirt_vmsnapshot_persistentvolumeclaim_labels"
+    ],
+    "hco": [
+      "cnv_abnormal",
+      "kubevirt_hyperconverged_operator_health_status"
+    ],
+    "cdi": [
+      "kubevirt_cdi_clone_pods_high_restart",
+      "kubevirt_cdi_import_pods_high_restart",
+      "kubevirt_cdi_operator_up",
+      "kubevirt_cdi_upload_pods_high_restart"
+    ],
+    "cnao": [
+      "kubevirt_cnao_cr_kubemacpool_aggregated",
+      "kubevirt_cnao_kubemacpool_duplicate_macs",
+      "kubevirt_cnao_kubemacpool_manager_up",
+      "kubevirt_cnao_operator_up"
+    ],
+    "hpp": [
+      "kubevirt_hpp_operator_up"
+    ],
+    "ssp": [
+      "cnv:vmi_status_running:count",
+      "kubevirt_ssp_common_templates_restored_increase",
+      "kubevirt_ssp_operator_reconcile_succeeded_aggregated",
+      "kubevirt_ssp_operator_up",
+      "kubevirt_ssp_template_validator_rejected_increase",
+      "kubevirt_ssp_template_validator_up"
+    ]
+  }
+}
+

--- a/test/metrics/prom-metrics-linter/custom_linter_rules.go
+++ b/test/metrics/prom-metrics-linter/custom_linter_rules.go
@@ -20,26 +20,27 @@ package main
 
 import (
 	"fmt"
-	"sort"
+	"os"
+	"regexp"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus/testutil/promlint"
 	dto "github.com/prometheus/client_model/go"
 )
 
-func CustomLinterRules(problems []promlint.Problem, mf *dto.MetricFamily, operatorName, subOperatorName string) []promlint.Problem {
-	// Check metric prefix
+func CustomMetricsValidation(problems []promlint.Problem, mf *dto.MetricFamily, operatorName, subOperatorName string) []promlint.Problem {
+	// Validate metric prefix
 	nameParts := strings.Split(*mf.Name, "_")
 
 	if nameParts[0] != operatorName {
 		problems = append(problems, promlint.Problem{
 			Metric: *mf.Name,
-			Text:   fmt.Sprintf("name need to start with '%s_'", operatorName),
+			Text:   fmt.Sprintf(`name need to start with %s_`, operatorName),
 		})
 	} else if operatorName != subOperatorName && nameParts[1] != subOperatorName {
 		problems = append(problems, promlint.Problem{
 			Metric: *mf.Name,
-			Text:   fmt.Sprintf("name need to start with \"%s_%s_\"", operatorName, subOperatorName),
+			Text:   fmt.Sprintf(`name need to start with "%s_%s_"`, operatorName, subOperatorName),
 		})
 	}
 
@@ -56,10 +57,158 @@ func CustomLinterRules(problems []promlint.Problem, mf *dto.MetricFamily, operat
 		}
 	}
 
-	// Sort the problems by metric name
-	sort.Slice(newProblems, func(i, j int) bool {
-		return newProblems[i].Metric < newProblems[j].Metric
-	})
-
 	return newProblems
+}
+
+func CustomRecordingRuleValidation(rr recordingRule) []promlint.Problem {
+	var problems []promlint.Problem
+
+	name := rr.Record
+	if name == "" {
+		return problems
+	}
+
+	// Require name structure: level:metric:operations
+	parts, nameOkProblems, ok := validateRecordingRuleNameStructure(name)
+	if !ok {
+		return append(problems, nameOkProblems...)
+	}
+
+	// Enforce metric segment prefix: it should start with operator_suboperator like metrics do
+	problems = append(problems, validateRecordingRuleMetricPrefix(name, parts, operatorName, subOperatorName)...)
+
+	// Single/Multiple operations: detect ops in expr and enforce suffix rules
+	problems = append(problems, validateRecordingRuleOpsSuffix(rr, parts)...)
+
+	// Forbid duplicated operations
+	problems = append(problems, validateRecordingRuleNoDuplicateOps(name, parts)...)
+
+	return problems
+}
+
+func validateRecordingRuleNameStructure(name string) ([]string, []promlint.Problem, bool) {
+	parts := strings.Split(name, ":")
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return nil, []promlint.Problem{
+			{Metric: name, Text: "recording rule name must be level:metric:operations. if there is no obvious operations, use 'sum'"},
+		}, false
+	}
+	return parts, nil, true
+}
+
+func validateRecordingRuleMetricPrefix(name string, parts []string, operatorName, subOperatorName string) []promlint.Problem {
+	var problems []promlint.Problem
+	metricPart := parts[1]
+	expectedPrefix := operatorName + "_"
+	if operatorName != subOperatorName {
+		expectedPrefix = operatorName + "_" + subOperatorName + "_"
+	}
+	if !strings.HasPrefix(metricPart, expectedPrefix) {
+		problems = append(problems, promlint.Problem{
+			Metric: name,
+			Text:   fmt.Sprintf("metric (second segment in level:metric:operations) need to start with %q", expectedPrefix),
+		})
+	}
+	return problems
+}
+
+func validateRecordingRuleOpsSuffix(rr recordingRule, parts []string) []promlint.Problem {
+	name := rr.Record
+	var problems []promlint.Problem
+
+	aggOps := detectOps(rr.Expr, promAggRegex)
+	timeOps := detectOps(rr.Expr, promTimeRegex)
+	total := len(aggOps) + len(timeOps)
+	opsPart := parts[2]
+
+	if total == 1 {
+		if len(aggOps) == 1 {
+			expected := aggOps[0]
+			if !strings.HasSuffix(opsPart, expected) {
+				problems = append(problems, promlint.Problem{
+					Metric: name,
+					Text:   fmt.Sprintf("single aggregation detected in expr: operations (third segment in level:metric:operations) should end with %q", expected),
+				})
+			}
+		} else if len(timeOps) == 1 {
+			expected := timeOps[0]
+			timeSuffixRe, err := regexp.Compile(`(?i)` + expected + `[0-9]+[smhdwy]+$`)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "time op suffix regex compile failed for %q: %v\n", expected, err)
+			} else if !timeSuffixRe.MatchString(opsPart) {
+				problems = append(problems, promlint.Problem{
+					Metric: name,
+					Text:   fmt.Sprintf("single time operation detected in expr: operations (third segment in level:metric:operations) should end with %q", expected+"<duration>"),
+				})
+			}
+		}
+	} else if total > 1 {
+		present := false
+		for _, op := range append(aggOps, timeOps...) {
+			if strings.Contains(opsPart, op) {
+				present = true
+				break
+			}
+		}
+		if !present {
+			problems = append(problems, promlint.Problem{
+				Metric: name,
+				Text:   "multiple operations detected in expr: at least one operation should appear in operations (third segment in level:metric:operations)",
+			})
+		}
+	}
+	return problems
+}
+
+func validateRecordingRuleNoDuplicateOps(name string, parts []string) []promlint.Problem {
+	var problems []promlint.Problem
+	seen := map[string]struct{}{}
+	tokens := strings.Split(parts[2], "_")
+	for _, tok := range tokens {
+		if tok == "" {
+			continue
+		}
+		if _, ok := seen[tok]; ok {
+			problems = append(problems, promlint.Problem{
+				Metric: name,
+				Text:   "operations (third segment in level:metric:operations) contains duplicate tokens; merge duplicates (e.g., min_min -> min)",
+			})
+			break
+		}
+		seen[tok] = struct{}{}
+	}
+	return problems
+}
+
+var (
+	promAggOps = []string{
+		// Aggregations
+		"sum", "avg", "min", "max", "count", "quantile", "stddev", "stdvar",
+		"group", "count_values", "limitk", "limit_ratio",
+		// Selectors considered as aggregations
+		"topk", "bottomk",
+	}
+	promTimeOps = []string{
+		// Time/transform functions
+		"rate", "irate", "increase", "delta", "idelta", "deriv",
+		"avg_over_time", "min_over_time", "max_over_time", "sum_over_time",
+		"count_over_time", "quantile_over_time", "stddev_over_time", "stdvar_over_time",
+	}
+	// Precompiled regexes for op detection
+	promAggRegex  = regexp.MustCompile(`\b(` + strings.Join(promAggOps, "|") + `)\b`)
+	promTimeRegex = regexp.MustCompile(`\b(` + strings.Join(promTimeOps, "|") + `)\b`)
+)
+
+func detectOps(expr string, re *regexp.Regexp) []string {
+	uniq := map[string]struct{}{}
+	for _, m := range re.FindAllStringSubmatch(expr, -1) {
+		if len(m) > 1 {
+			uniq[m[1]] = struct{}{}
+		}
+	}
+	var opsList []string
+	for k := range uniq {
+		opsList = append(opsList, k)
+	}
+	return opsList
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This pr will allow kubevirt and other operators to send metrics and recording rules separately in one JSON (two lists). The linter will run promlint and our existing custom checks on metrics, and it will validate recording rule names against the level:metric:operations format and more custom checks:

- Name structure
  - Must be level:metric:operations (three non-empty segments).
  - If no obvious operation, suggest using 'sum' in the operations segment (not mandatory)
  - metric part should start with operator_sub-operator e.g. kubevirt_hco, kubevirt (if operator=sub-operator just start with operator)

- Single operation in expr
  - Aggregation (sum/avg/min/max/count/...): operations (third segment) must end with that op.
  - Time op (rate/irate/increase/delta/idelta/deriv/_over_time): operations must end with op+duration (e.g., rate5m).

- Multiple operations in expr
  - At least one operation token from the expr must appear in operations (third segment).

- duplicate operations suffix
  - Forbid duplicate tokens anywhere in operations (e.g., min_min or min_max_count_min).


**Which issue(s) this PR fixes**:
jira-ticket: https://issues.redhat.com/browse/CNV-71410

**Special notes for your reviewer**:
to avoid breaking existing rules, the linter (in the monitoring repo) will include an operator-scoped allowlist for current names, any new rule that isn’t on that list will fail CI. this keeps all policy and exceptions in the monitoring repo (no future kubevirt changes), and in a couple of versions, once old names are gone, we just remove the allowlist from monitoring and bump the linter version in kubevirt/other operators.
 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
metric name linter is now supporting recording rules and enforce custom rules on their names
```
