### PR TITLE
Build riscv64 image

### DIFF
--- a/.github/workflows/prom-metrics-linter.yaml
+++ b/.github/workflows/prom-metrics-linter.yaml
@@ -5,7 +5,7 @@ on:
       - published
 env:
   IMAGE_NAME: quay.io/kubevirt/prom-metrics-linter
-  BUILD_PLATFORMS: linux/amd64,linux/arm64,linux/s390x
+  BUILD_PLATFORMS: linux/amd64,linux/arm64,linux/s390x,linux/riscv64
 
 jobs:
   build:

--- a/test/metrics/prom-metrics-linter/Dockerfile
+++ b/test/metrics/prom-metrics-linter/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 RUN go mod tidy && \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -v -trimpath -ldflags "-s -w" -o /bin/ .
 
-FROM --platform=${TARGETOS}/${TARGETARCH} gcr.io/distroless/base:latest
+FROM --platform=${TARGETOS}/${TARGETARCH} alpine:latest
 
 COPY --from=build /bin/prom-metrics-linter .
 


### PR DESCRIPTION
**What this PR does / why we need it**:

I'm currently working on adding riscv64 support for kubevirt, as detailed in https://github.com/kubevirt/containerized-data-importer/issues/3948. While adding support for CDI, I discovered that this repository needs riscv64 support as well, so I've opened this PR to add riscv64 support.

By checking gcr.io/distroless/base:latest and alpine:latest , we can see the following table:

| arch     | distroless/base | alpine |
| -------- | --------------- | ------ |
| amd64    | Y               | Y      |
| arm64/v8 | Y               | Y      |
| arm/v7   | Y               | Y      |
| s390x    | Y               | Y      |
| ppc64le  | Y               | Y      |
| riscv64  | N               | Y      |
| 386      | N               | Y      |
| arm/v6   | N               | Y      |

Clearly, Alpine has excellent multi-architecture support. Should we consider switching from distroless/base to Alpine to gain riscv64 support? I believe there shouldn't be any compatibility issues between the two, but I haven't yet found a good approach for testing this image in CI. If I find one, I'll submit the relevant PR promptly.

For now, I've run the CI in my own fork, and the results show everything is working smoothly. Details are as follows:
1. [prom-metrics-linter](https://github.com/ffgan/monitoring/actions/runs/19321668499)
2. [Generate a build and push to 'ghpages' branch](https://github.com/ffgan/monitoring/actions/runs/19321668511)
3. [Sanity Checks](https://github.com/ffgan/monitoring/actions/runs/19321668502)

If you have any questions about the above content, please feel free to contact me directly. I'm happy to answer any related questions.

---
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Build riscv64 image
```

---
Otehr Info
Co-authored by: nijincheng@iscas.ac.cn;

