### PR TITLE
Runbook for new Ephemeral Hotplug Volume Metric

### DIFF
--- a/docs/runbooks/VirtualMachineInstanceHasEphemeralHotplugVolume.md
+++ b/docs/runbooks/VirtualMachineInstanceHasEphemeralHotplugVolume.md
@@ -1,0 +1,52 @@
+# VirtualMachineInstanceHasEphemeralHotplugVolume
+
+## Meaning
+
+The `VirtualMachineInstanceHasEphemeralHotplugVolume` alert is triggered when a
+Virtual Machine Instance (VMI) contains an Ephemeral Hotplug Volume, which is defined
+as a hotplug volume that only exists in the VMI and will not persist during VM restart
+
+## Impact
+
+The `HotplugVolumes` Feature Gate will be deprecated in a future release and will
+be replaced by the `DeclarativeHotplugVolumes` Feature Gate. The two are mutually
+exclusive, and when `DeclarativeHotplugVolumes` is enabled, any remaining
+ephemeral hotplug volumes will automatically be unplugged from any VMIs.
+
+If this alert is triggered, it is to inform of this future deprecation and to
+suggest steps to convert ephermeral volumes to persist ones.
+
+## Diagnosis
+
+To diagnose the cause of this alert, the following steps can be taken:
+
+1. Find each VM that contains an ephemeral hotplug volume.
+   This command will print out list entries in format [vm-name, namespace]
+    ``` bash
+    $ kubectl get vmis -A -o json | jq -r '.items[].metadata | select(.annotations | has("kubevirt.io/ephemeral-hotplug-volumes")) | [.name , .namespace] | @tsv'
+    ```
+2. For each VM listed, find the volumes that need to be patched.
+
+   ``` bash
+   $ kubectl get vmis <vm-name> -n <namespace> -o json | jq -r '.metadata.annotations."kubevirt.io/ephemeral-hotplug-volumes"'
+   ```
+
+## Mitigation
+
+To mitigate the impact of this alert, consider converting these ephemeral
+hotplug volumes to instead persist within the VM.
+
+To do so:
+``` bash
+$ virtctl addvolume <vm-name> --volume-name=<volume-name> --persist
+```
+
+<!--DS: If you cannot resolve the issue, log in to the
+link:https://access.redhat.com[Customer Portal] and open a support case,
+attaching the artifacts gathered during the diagnosis procedure.-->
+<!--USstart-->
+If you cannot resolve the issue, see the following resources:
+
+- [OKD Help](https://okd.io/docs/community/help/)
+- [#virtualization Slack channel](https://kubernetes.slack.com/channels/virtualization)
+<!--USend-->


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Adding new runbook for Alert that is to be merged in kubevirt. Alert is fired when a VMI contains an ephemeral hotplug volume. Runbook is to notify user of future deprecation of the feature and to advise steps on how to convert these ephemeral volumes into persistent volumes.

Kubevirt PR that adds new metric/alert: https://github.com/kubevirt/kubevirt/pull/15815

Jira: https://issues.redhat.com/browse/CNV-69387


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
