### PR TITLE
changing metrics.md presentation to table format

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -4,539 +4,190 @@ This document aims to help users that are not familiar with metrics exposed by a
 All metrics documented here are auto-generated in each component repository and gathered here.
 They reflect and describe exactly what is being exposed.
 
-## Table of Contents
+## Operator Repositories
+
+| Operator Name |
+|---------------|
+| [kubevirt](https://github.com/kubevirt/kubevirt/tree/main) |
+| [cluster-network-addons-operator](https://github.com/kubevirt/cluster-network-addons-operator/tree/main) |
+| [containerized-data-importer](https://github.com/kubevirt/containerized-data-importer/tree/main) |
+| [hostpath-provisioner](https://github.com/kubevirt/hostpath-provisioner/tree/main) |
+| [hostpath-provisioner-operator](https://github.com/kubevirt/hostpath-provisioner-operator/tree/main) |
+| [hyperconverged-cluster-operator](https://github.com/kubevirt/hyperconverged-cluster-operator/tree/main) |
+| [ssp-operator](https://github.com/kubevirt/ssp-operator/tree/main) |
+
+
+## Metrics
+
+The following table contains all metrics from operators listed above. Each row represents a single metric with its operator, name, type (Gauge, Counter, Histogram, etc.), and description.
+
+| Operator Name | Metric Name | Type | Description |
+|----------|------|------|-------------|
+| kubevirt | `cluster:kubevirt_virt_controller_pods_running:count` | Gauge | The number of virt-controller pods that are running |
+| kubevirt | `kubevirt_allocatable_nodes` | Gauge | The number of allocatable nodes in the cluster |
+| kubevirt | `kubevirt_api_request_deprecated_total` | Counter | The total number of requests to deprecated KubeVirt APIs |
+| kubevirt | `kubevirt_configuration_emulation_enabled` | Gauge | Indicates whether the Software Emulation is enabled in the configuration |
+| kubevirt | `kubevirt_console_active_connections` | Gauge | Amount of active Console connections, broken down by namespace and vmi name |
+| kubevirt | `kubevirt_info` | Gauge | Version information |
+| kubevirt | `kubevirt_memory_delta_from_requested_bytes` | Gauge | The delta between the pod with highest memory working set or rss and its requested memory for each container, virt-controller, virt-handler, virt-api, virt-operator and compute(virt-launcher) |
+| kubevirt | `kubevirt_node_deprecated_machine_types` | Gauge | List of deprecated machine types based on the capabilities of individual nodes, as detected by virt-handler |
+| kubevirt | `kubevirt_nodes_with_kvm` | Gauge | The number of nodes in the cluster that have the devices.kubevirt.io/kvm resource available |
+| kubevirt | `kubevirt_number_of_vms` | Gauge | The number of VMs in the cluster by namespace |
+| kubevirt | `kubevirt_portforward_active_tunnels` | Gauge | Amount of active portforward tunnels, broken down by namespace and vmi name |
+| kubevirt | `kubevirt_rest_client_rate_limiter_duration_seconds` | Histogram | Client side rate limiter latency in seconds. Broken down by verb and URL |
+| kubevirt | `kubevirt_rest_client_request_latency_seconds` | Histogram | Request latency in seconds. Broken down by verb and URL |
+| kubevirt | `kubevirt_rest_client_requests_total` | Counter | Number of HTTP requests, partitioned by status code, method, and host |
+| kubevirt | `kubevirt_usbredir_active_connections` | Gauge | Amount of active USB redirection connections, broken down by namespace and vmi name |
+| kubevirt | `kubevirt_virt_api_up` | Gauge | The number of virt-api pods that are up |
+| kubevirt | `kubevirt_virt_controller_leading_status` | Gauge | Indication for an operating virt-controller |
+| kubevirt | `kubevirt_virt_controller_ready` | Gauge | The number of virt-controller pods that are ready |
+| kubevirt | `kubevirt_virt_controller_ready_status` | Gauge | Indication for a virt-controller that is ready to take the lead |
+| kubevirt | `kubevirt_virt_controller_up` | Gauge | The number of virt-controller pods that are up |
+| kubevirt | `kubevirt_virt_handler_up` | Gauge | The number of virt-handler pods that are up |
+| kubevirt | `kubevirt_virt_operator_leading` | Gauge | The number of virt-operator pods that are leading |
+| kubevirt | `kubevirt_virt_operator_leading_status` | Gauge | Indication for an operating virt-operator |
+| kubevirt | `kubevirt_virt_operator_ready` | Gauge | The number of virt-operator pods that are ready |
+| kubevirt | `kubevirt_virt_operator_ready_status` | Gauge | Indication for a virt-operator that is ready to take the lead |
+| kubevirt | `kubevirt_virt_operator_up` | Gauge | The number of virt-operator pods that are up |
+| kubevirt | `kubevirt_vm_container_memory_request_margin_based_on_rss_bytes` | Gauge | Difference between requested memory and rss for VM containers (request margin). Can be negative when usage exceeds request |
+| kubevirt | `kubevirt_vm_container_memory_request_margin_based_on_working_set_bytes` | Gauge | Difference between requested memory and working set for VM containers (request margin). Can be negative when usage exceeds request |
+| kubevirt | `kubevirt_vm_create_date_timestamp_seconds` | Gauge | Virtual Machine creation timestamp |
+| kubevirt | `kubevirt_vm_created_by_pod_total` | Counter | The total number of VMs created by namespace and virt-api pod, since install |
+| kubevirt | `kubevirt_vm_created_total` | Counter | The total number of VMs created by namespace, since install |
+| kubevirt | `kubevirt_vm_disk_allocated_size_bytes` | Gauge | Allocated disk size of a Virtual Machine in bytes, based on its PersistentVolumeClaim. Includes persistentvolumeclaim (PVC name), volume_mode (disk presentation mode: Filesystem or Block), and device (disk name) |
+| kubevirt | `kubevirt_vm_error_status_last_transition_timestamp_seconds` | Counter | Virtual Machine last transition timestamp to error status |
+| kubevirt | `kubevirt_vm_info` | Gauge | Information about Virtual Machines |
+| kubevirt | `kubevirt_vm_labels` | Gauge | The metric exposes the VM labels as Prometheus labels. Configure allowed and ignored labels via the 'kubevirt-vm-labels-config' ConfigMap |
+| kubevirt | `kubevirt_vm_migrating_status_last_transition_timestamp_seconds` | Counter | Virtual Machine last transition timestamp to migrating status |
+| kubevirt | `kubevirt_vm_non_running_status_last_transition_timestamp_seconds` | Counter | Virtual Machine last transition timestamp to paused/stopped status |
+| kubevirt | `kubevirt_vm_resource_limits` | Gauge | Resources limits by Virtual Machine. Reports memory and CPU limits |
+| kubevirt | `kubevirt_vm_resource_requests` | Gauge | Resources requested by Virtual Machine. Reports memory and CPU requests |
+| kubevirt | `kubevirt_vm_running_status_last_transition_timestamp_seconds` | Counter | Virtual Machine last transition timestamp to running status |
+| kubevirt | `kubevirt_vm_starting_status_last_transition_timestamp_seconds` | Counter | Virtual Machine last transition timestamp to starting status |
+| kubevirt | `kubevirt_vm_vnic_info` | Gauge | Details of Virtual Machine (VM) vNIC interfaces, such as vNIC name, binding type, network name, and binding name for each vNIC defined in the VM's configuration |
+| kubevirt | `kubevirt_vmi_cpu_system_usage_seconds_total` | Counter | Total CPU time spent in system mode |
+| kubevirt | `kubevirt_vmi_cpu_usage_seconds_total` | Counter | Total CPU time spent in all modes (sum of both vcpu and hypervisor usage) |
+| kubevirt | `kubevirt_vmi_cpu_user_usage_seconds_total` | Counter | Total CPU time spent in user mode |
+| kubevirt | `kubevirt_vmi_dirty_rate_bytes_per_second` | Gauge | Guest dirty-rate in bytes per second |
+| kubevirt | `kubevirt_vmi_filesystem_capacity_bytes` | Gauge | Total VM filesystem capacity in bytes |
+| kubevirt | `kubevirt_vmi_filesystem_used_bytes` | Gauge | Used VM filesystem capacity in bytes |
+| kubevirt | `kubevirt_vmi_guest_load_15m` | Gauge | Guest system load average over 15 minutes as reported by the guest agent. Load is defined as the number of processes in the runqueue or waiting for disk I/O. Requires qemu-guest-agent version 10.0.0 or above |
+| kubevirt | `kubevirt_vmi_guest_load_1m` | Gauge | Guest system load average over 1 minute as reported by the guest agent. Load is defined as the number of processes in the runqueue or waiting for disk I/O. Requires qemu-guest-agent version 10.0.0 or above |
+| kubevirt | `kubevirt_vmi_guest_load_5m` | Gauge | Guest system load average over 5 minutes as reported by the guest agent. Load is defined as the number of processes in the runqueue or waiting for disk I/O. Requires qemu-guest-agent version 10.0.0 or above |
+| kubevirt | `kubevirt_vmi_guest_vcpu_queue` | Gauge | Guest queue length |
+| kubevirt | `kubevirt_vmi_info` | Gauge | Information about VirtualMachineInstances |
+| kubevirt | `kubevirt_vmi_last_api_connection_timestamp_seconds` | Gauge | Virtual Machine Instance last API connection timestamp. Including VNC, console, portforward, SSH and usbredir connections |
+| kubevirt | `kubevirt_vmi_launcher_memory_overhead_bytes` | Gauge | Estimation of the memory amount required for virt-launcher's infrastructure components (e.g. libvirt, QEMU) |
+| kubevirt | `kubevirt_vmi_memory_actual_balloon_bytes` | Gauge | Current balloon size in bytes |
+| kubevirt | `kubevirt_vmi_memory_available_bytes` | Gauge | Amount of usable memory as seen by the domain. This value may not be accurate if a balloon driver is in use or if the guest OS does not initialize all assigned pages |
+| kubevirt | `kubevirt_vmi_memory_cached_bytes` | Gauge | The amount of memory that is being used to cache I/O and is available to be reclaimed, corresponds to the sum of `Buffers` + `Cached` + `SwapCached` in `/proc/meminfo` |
+| kubevirt | `kubevirt_vmi_memory_domain_bytes` | Gauge | The amount of memory in bytes allocated to the domain. The `memory` value in domain xml file |
+| kubevirt | `kubevirt_vmi_memory_pgmajfault_total` | Counter | The number of page faults when disk IO was required. Page faults occur when a process makes a valid access to virtual memory that is not available. When servicing the page fault, if disk IO is required, it is considered as major fault |
+| kubevirt | `kubevirt_vmi_memory_pgminfault_total` | Counter | The number of other page faults, when disk IO was not required. Page faults occur when a process makes a valid access to virtual memory that is not available. When servicing the page fault, if disk IO is NOT required, it is considered as minor fault |
+| kubevirt | `kubevirt_vmi_memory_resident_bytes` | Gauge | Resident set size of the process running the domain |
+| kubevirt | `kubevirt_vmi_memory_swap_in_traffic_bytes` | Gauge | The total amount of data read from swap space of the guest in bytes |
+| kubevirt | `kubevirt_vmi_memory_swap_out_traffic_bytes` | Gauge | The total amount of memory written out to swap space of the guest in bytes |
+| kubevirt | `kubevirt_vmi_memory_unused_bytes` | Gauge | The amount of memory left completely unused by the system. Memory that is available but used for reclaimable caches should NOT be reported as free |
+| kubevirt | `kubevirt_vmi_memory_usable_bytes` | Gauge | The amount of memory which can be reclaimed by balloon without pushing the guest system to swap, corresponds to 'Available' in /proc/meminfo |
+| kubevirt | `kubevirt_vmi_memory_used_bytes` | Gauge | Amount of `used` memory as seen by the domain |
+| kubevirt | `kubevirt_vmi_migration_data_processed_bytes` | Gauge | The total Guest OS data processed and migrated to the new VM |
+| kubevirt | `kubevirt_vmi_migration_data_remaining_bytes` | Gauge | The remaining guest OS data to be migrated to the new VM |
+| kubevirt | `kubevirt_vmi_migration_data_total_bytes` | Counter | The total Guest OS data to be migrated to the new VM |
+| kubevirt | `kubevirt_vmi_migration_dirty_memory_rate_bytes` | Gauge | The rate of memory being dirty in the Guest OS |
+| kubevirt | `kubevirt_vmi_migration_end_time_seconds` | Gauge | The time at which the migration ended |
+| kubevirt | `kubevirt_vmi_migration_failed` | Gauge | Indicates if the VMI migration failed |
+| kubevirt | `kubevirt_vmi_migration_memory_transfer_rate_bytes` | Gauge | The rate at which the memory is being transferred |
+| kubevirt | `kubevirt_vmi_migration_phase_transition_time_from_creation_seconds` | Histogram | Histogram of VM migration phase transitions duration from creation time in seconds |
+| kubevirt | `kubevirt_vmi_migration_start_time_seconds` | Gauge | The time at which the migration started |
+| kubevirt | `kubevirt_vmi_migration_succeeded` | Gauge | Indicates if the VMI migration succeeded |
+| kubevirt | `kubevirt_vmi_migrations_in_pending_phase` | Gauge | Number of current pending migrations |
+| kubevirt | `kubevirt_vmi_migrations_in_running_phase` | Gauge | Number of current running migrations |
+| kubevirt | `kubevirt_vmi_migrations_in_scheduling_phase` | Gauge | Number of current scheduling migrations |
+| kubevirt | `kubevirt_vmi_migrations_in_unset_phase` | Gauge | Number of current unset migrations. These are pending items the virt-controller hasn’t processed yet from the queue |
+| kubevirt | `kubevirt_vmi_network_receive_bytes_total` | Counter | Total network traffic received in bytes |
+| kubevirt | `kubevirt_vmi_network_receive_errors_total` | Counter | Total network received error packets |
+| kubevirt | `kubevirt_vmi_network_receive_packets_dropped_total` | Counter | The total number of rx packets dropped on vNIC interfaces |
+| kubevirt | `kubevirt_vmi_network_receive_packets_total` | Counter | Total network traffic received packets |
+| kubevirt | `kubevirt_vmi_network_traffic_bytes_total` | Counter | [Deprecated] Total number of bytes sent and received |
+| kubevirt | `kubevirt_vmi_network_transmit_bytes_total` | Counter | Total network traffic transmitted in bytes |
+| kubevirt | `kubevirt_vmi_network_transmit_errors_total` | Counter | Total network transmitted error packets |
+| kubevirt | `kubevirt_vmi_network_transmit_packets_dropped_total` | Counter | The total number of tx packets dropped on vNIC interfaces |
+| kubevirt | `kubevirt_vmi_network_transmit_packets_total` | Counter | Total network traffic transmitted packets |
+| kubevirt | `kubevirt_vmi_node_cpu_affinity` | Gauge | Number of VMI CPU affinities to node physical cores |
+| kubevirt | `kubevirt_vmi_non_evictable` | Gauge | Indication for a VirtualMachine that its eviction strategy is set to Live Migration but is not migratable |
+| kubevirt | `kubevirt_vmi_number_of_outdated` | Gauge | Indication for the total number of VirtualMachineInstance workloads that are not running within the most up-to-date version of the virt-launcher environment |
+| kubevirt | `kubevirt_vmi_phase_count` | Gauge | Sum of VMIs per phase and node. `phase` can be one of the following: [`Pending`, `Scheduling`, `Scheduled`, `Running`, `Succeeded`, `Failed`, `Unknown`] |
+| kubevirt | `kubevirt_vmi_phase_transition_time_from_creation_seconds` | Histogram | Histogram of VM phase transitions duration from creation time in seconds |
+| kubevirt | `kubevirt_vmi_phase_transition_time_from_deletion_seconds` | Histogram | Histogram of VM phase transitions duration from deletion time in seconds |
+| kubevirt | `kubevirt_vmi_phase_transition_time_seconds` | Histogram | Histogram of VM phase transitions duration between different phases in seconds |
+| kubevirt | `kubevirt_vmi_status_addresses` | Gauge | The addresses of a VirtualMachineInstance. This metric provides the address of an available network interface associated with the VMI in the 'address' label, and about the type of address, such as internal IP, in the 'type' label |
+| kubevirt | `kubevirt_vmi_storage_flush_requests_total` | Counter | Total storage flush requests |
+| kubevirt | `kubevirt_vmi_storage_flush_times_seconds_total` | Counter | Total time spent on cache flushing |
+| kubevirt | `kubevirt_vmi_storage_iops_read_total` | Counter | Total number of I/O read operations |
+| kubevirt | `kubevirt_vmi_storage_iops_write_total` | Counter | Total number of I/O write operations |
+| kubevirt | `kubevirt_vmi_storage_read_times_seconds_total` | Counter | Total time spent on read operations |
+| kubevirt | `kubevirt_vmi_storage_read_traffic_bytes_total` | Counter | Total number of bytes read from storage |
+| kubevirt | `kubevirt_vmi_storage_write_times_seconds_total` | Counter | Total time spent on write operations |
+| kubevirt | `kubevirt_vmi_storage_write_traffic_bytes_total` | Counter | Total number of written bytes |
+| kubevirt | `kubevirt_vmi_vcpu_delay_seconds_total` | Counter | Amount of time spent by each vcpu waiting in the queue instead of running |
+| kubevirt | `kubevirt_vmi_vcpu_seconds_total` | Counter | Total amount of time spent in each state by each vcpu (cpu_time excluding hypervisor time). Where `id` is the vcpu identifier and `state` can be one of the following: [`OFFLINE`, `RUNNING`, `BLOCKED`] |
+| kubevirt | `kubevirt_vmi_vcpu_wait_seconds_total` | Counter | Amount of time spent by each vcpu while waiting on I/O |
+| kubevirt | `kubevirt_vmi_vnic_info` | Gauge | Details of VirtualMachineInstance (VMI) vNIC interfaces, such as vNIC name, binding type, network name, and binding name for each vNIC of a running instance |
+| kubevirt | `kubevirt_vmsnapshot_disks_restored_from_source` | Gauge | Returns the total number of virtual machine disks restored from the source virtual machine |
+| kubevirt | `kubevirt_vmsnapshot_disks_restored_from_source_bytes` | Gauge | Returns the amount of space in bytes restored from the source virtual machine |
+| kubevirt | `kubevirt_vmsnapshot_persistentvolumeclaim_labels` | Gauge | Returns the labels of the persistent volume claims that are used for restoring virtual machines |
+| kubevirt | `kubevirt_vmsnapshot_succeeded_timestamp_seconds` | Gauge | Returns the timestamp of successful virtual machine snapshot |
+| kubevirt | `kubevirt_vnc_active_connections` | Gauge | Amount of active VNC connections, broken down by namespace and vmi name |
+| kubevirt | `kubevirt_workqueue_adds_total` | Counter | Total number of adds handled by workqueue |
+| kubevirt | `kubevirt_workqueue_depth` | Gauge | Current depth of workqueue |
+| kubevirt | `kubevirt_workqueue_longest_running_processor_seconds` | Gauge | How many seconds has the longest running processor for workqueue been running |
+| kubevirt | `kubevirt_workqueue_queue_duration_seconds` | Histogram | How long an item stays in workqueue before being requested |
+| kubevirt | `kubevirt_workqueue_retries_total` | Counter | Total number of retries handled by workqueue |
+| kubevirt | `kubevirt_workqueue_unfinished_work_seconds` | Gauge | How many seconds of work has done that is in progress and hasn't been observed by work_duration. Large values indicate stuck threads. One can deduce the number of stuck threads by observing the rate at which this increases |
+| kubevirt | `kubevirt_workqueue_work_duration_seconds` | Histogram | How long in seconds processing an item from workqueue takes |
+| kubevirt | `vmi:kubevirt_vmi_vcpu:count` | Gauge | The number of the VMI vCPUs |
+| cluster-network-addons-operator | `kubevirt_cnao_cr_kubemacpool_aggregated` | Gauge | Total count of KubeMacPool manager pods deployed by CNAO CR |
+| cluster-network-addons-operator | `kubevirt_cnao_cr_kubemacpool_deployed` | Gauge | KubeMacpool is deployed by CNAO CR |
+| cluster-network-addons-operator | `kubevirt_cnao_cr_ready` | Gauge | CNAO CR Ready |
+| cluster-network-addons-operator | `kubevirt_cnao_kubemacpool_duplicate_macs` | Gauge | Total count of duplicate KubeMacPool MAC addresses |
+| cluster-network-addons-operator | `kubevirt_cnao_kubemacpool_manager_up` | Gauge | Total count of running KubeMacPool manager pods |
+| cluster-network-addons-operator | `kubevirt_cnao_operator_up` | Gauge | Total count of running CNAO operators |
+| containerized-data-importer | `kubevirt_cdi_clone_pods_high_restart` | Gauge | The number of CDI clone pods with high restart count |
+| containerized-data-importer | `kubevirt_cdi_clone_progress_total` | Counter | The clone progress in percentage |
+| containerized-data-importer | `kubevirt_cdi_cr_ready` | Gauge | CDI install ready |
+| containerized-data-importer | `kubevirt_cdi_dataimportcron_outdated` | Gauge | DataImportCron has an outdated import |
+| containerized-data-importer | `kubevirt_cdi_datavolume_pending` | Gauge | Number of DataVolumes pending for default storage class to be configured |
+| containerized-data-importer | `kubevirt_cdi_import_pods_high_restart` | Gauge | The number of CDI import pods with high restart count |
+| containerized-data-importer | `kubevirt_cdi_import_progress_total` | Counter | The import progress in percentage |
+| containerized-data-importer | `kubevirt_cdi_openstack_populator_progress_total` | Counter | Progress of volume population |
+| containerized-data-importer | `kubevirt_cdi_operator_up` | Gauge | CDI operator status |
+| containerized-data-importer | `kubevirt_cdi_ovirt_progress_total` | Counter | Progress of volume population |
+| containerized-data-importer | `kubevirt_cdi_storageprofile_info` | Gauge | `StorageProfiles` info labels: `storageclass`, `provisioner`, `complete` indicates if all storage profiles recommended PVC settings are complete, `default` indicates if it's the Kubernetes default storage class, `virtdefault` indicates if it's the default virtualization storage class, `rwx` indicates if the storage class supports `ReadWriteMany`, `smartclone` indicates if it supports snapshot or CSI based clone, `degraded` indicates it is not optimal for virtualization |
+| containerized-data-importer | `kubevirt_cdi_upload_pods_high_restart` | Gauge | The number of CDI upload server pods with high restart count |
+| hostpath-provisioner | `kubevirt_hpp_pool_path_shared_with_os` | Gauge | HPP pool path sharing a filesystem with OS, fix to prevent HPP PVs from causing disk pressure and affecting node operation |
+| hostpath-provisioner-operator | `kubevirt_hpp_cr_ready` | Gauge | HPP CR Ready |
+| hostpath-provisioner-operator | `kubevirt_hpp_operator_up` | Gauge | The number of running hostpath-provisioner-operator pods |
+| hyperconverged-cluster-operator | `cluster:vmi_request_cpu_cores:sum` | Gauge | Sum of CPU core requests for all running virt-launcher VMIs across the entire Kubevirt cluster |
+| hyperconverged-cluster-operator | `cnv_abnormal` | Gauge | Monitors resources for potential problems |
+| hyperconverged-cluster-operator | `kubevirt_hco_dataimportcrontemplate_with_architecture_annotation` | Gauge | Indicates whether the DataImportCronTemplate has the ssp.kubevirt.io/dict.architectures annotation (0) or not (1) |
+| hyperconverged-cluster-operator | `kubevirt_hco_dataimportcrontemplate_with_supported_architectures` | Gauge | Indicates whether the DataImportCronTemplate has supported architectures (0) or not (1) |
+| hyperconverged-cluster-operator | `kubevirt_hco_hyperconverged_cr_exists` | Gauge | Indicates whether the HyperConverged custom resource exists (1) or not (0) |
+| hyperconverged-cluster-operator | `kubevirt_hco_memory_overcommit_percentage` | Gauge | Indicates the cluster-wide configured VM memory overcommit percentage |
+| hyperconverged-cluster-operator | `kubevirt_hco_misconfigured_descheduler` | Gauge | Indicates whether the optional descheduler is not properly configured (1) to work with KubeVirt or not (0) |
+| hyperconverged-cluster-operator | `kubevirt_hco_out_of_band_modifications_total` | Counter | Count of out-of-band modifications overwritten by HCO |
+| hyperconverged-cluster-operator | `kubevirt_hco_single_stack_ipv6` | Gauge | Indicates whether the underlying cluster is single stack IPv6 (1) or not (0) |
+| hyperconverged-cluster-operator | `kubevirt_hco_system_health_status` | Gauge | Indicates whether the system health status is healthy (0), warning (1), or error (2), by aggregating the conditions of HCO and its secondary resources |
+| hyperconverged-cluster-operator | `kubevirt_hco_unsafe_modifications` | Gauge | Count of unsafe modifications in the HyperConverged annotations |
+| hyperconverged-cluster-operator | `kubevirt_hyperconverged_operator_health_status` | Gauge | Indicates whether HCO and its secondary resources health status is healthy (0), warning (1) or critical (2), based both on the firing alerts that impact the operator health, and on kubevirt_hco_system_health_status metric |
+| ssp-operator | `cnv:vmi_status_running:count` | Gauge | The total number of running VMIs, labeled with node, instance type, preference and guest OS information |
+| ssp-operator | `kubevirt_ssp_common_templates_restored_increase` | Gauge | The increase in the number of common templates restored by the operator back to their original state, over the last hour |
+| ssp-operator | `kubevirt_ssp_common_templates_restored_total` | Counter | The total number of common templates restored by the operator back to their original state |
+| ssp-operator | `kubevirt_ssp_operator_reconcile_succeeded` | Gauge | Set to 1 if the reconcile process of all operands completes with no errors, and to 0 otherwise |
+| ssp-operator | `kubevirt_ssp_operator_reconcile_succeeded_aggregated` | Gauge | The total number of ssp-operator pods reconciling with no errors |
+| ssp-operator | `kubevirt_ssp_operator_up` | Gauge | The total number of running ssp-operator pods |
+| ssp-operator | `kubevirt_ssp_template_validator_rejected_increase` | Gauge | The increase in the number of rejected template validators, over the last hour |
+| ssp-operator | `kubevirt_ssp_template_validator_rejected_total` | Counter | The total number of rejected template validators |
+| ssp-operator | `kubevirt_ssp_template_validator_up` | Gauge | The total number of running virt-template-validator pods |
+| ssp-operator | `kubevirt_ssp_vm_rbd_block_volume_without_rxbounce` | Gauge | [ALPHA] VM with RBD mounted Block volume (without rxbounce option set) |
 
-- [kubevirt](#kubevirt)
-- [containerized-data-importer](#containerized-data-importer)
-- [cluster-network-addons-operator](#cluster-network-addons-operator)
-- [ssp-operator](#ssp-operator)
-- [hostpath-provisioner-operator](#hostpath-provisioner-operator)
-- [hostpath-provisioner](#hostpath-provisioner)
-- [hyperconverged-cluster-operator](#hyperconverged-cluster-operator)
-
-<div id='kubevirt'></div>
-
-## [kubevirt](https://github.com/kubevirt/kubevirt/tree/main)
-
-### cluster:kubevirt_virt_controller_pods_running:count
-The number of virt-controller pods that are running. Type: Gauge.
-
-### kubevirt_allocatable_nodes
-The number of allocatable nodes in the cluster. Type: Gauge.
-
-### kubevirt_api_request_deprecated_total
-The total number of requests to deprecated KubeVirt APIs. Type: Counter.
-
-### kubevirt_configuration_emulation_enabled
-Indicates whether the Software Emulation is enabled in the configuration. Type: Gauge.
-
-### kubevirt_console_active_connections
-Amount of active Console connections, broken down by namespace and vmi name. Type: Gauge.
-
-### kubevirt_info
-Version information. Type: Gauge.
-
-### kubevirt_memory_delta_from_requested_bytes
-The delta between the pod with highest memory working set or rss and its requested memory for each container, virt-controller, virt-handler, virt-api, virt-operator and compute(virt-launcher). Type: Gauge.
-
-### kubevirt_node_deprecated_machine_types
-List of deprecated machine types based on the capabilities of individual nodes, as detected by virt-handler. Type: Gauge.
-
-### kubevirt_nodes_with_kvm
-The number of nodes in the cluster that have the devices.kubevirt.io/kvm resource available. Type: Gauge.
-
-### kubevirt_number_of_vms
-The number of VMs in the cluster by namespace. Type: Gauge.
-
-### kubevirt_portforward_active_tunnels
-Amount of active portforward tunnels, broken down by namespace and vmi name. Type: Gauge.
-
-### kubevirt_rest_client_rate_limiter_duration_seconds
-Client side rate limiter latency in seconds. Broken down by verb and URL. Type: Histogram.
-
-### kubevirt_rest_client_request_latency_seconds
-Request latency in seconds. Broken down by verb and URL. Type: Histogram.
-
-### kubevirt_rest_client_requests_total
-Number of HTTP requests, partitioned by status code, method, and host. Type: Counter.
-
-### kubevirt_usbredir_active_connections
-Amount of active USB redirection connections, broken down by namespace and vmi name. Type: Gauge.
-
-### kubevirt_virt_api_up
-The number of virt-api pods that are up. Type: Gauge.
-
-### kubevirt_virt_controller_leading_status
-Indication for an operating virt-controller. Type: Gauge.
-
-### kubevirt_virt_controller_ready
-The number of virt-controller pods that are ready. Type: Gauge.
-
-### kubevirt_virt_controller_ready_status
-Indication for a virt-controller that is ready to take the lead. Type: Gauge.
-
-### kubevirt_virt_controller_up
-The number of virt-controller pods that are up. Type: Gauge.
-
-### kubevirt_virt_handler_up
-The number of virt-handler pods that are up. Type: Gauge.
-
-### kubevirt_virt_operator_leading
-The number of virt-operator pods that are leading. Type: Gauge.
-
-### kubevirt_virt_operator_leading_status
-Indication for an operating virt-operator. Type: Gauge.
-
-### kubevirt_virt_operator_ready
-The number of virt-operator pods that are ready. Type: Gauge.
-
-### kubevirt_virt_operator_ready_status
-Indication for a virt-operator that is ready to take the lead. Type: Gauge.
-
-### kubevirt_virt_operator_up
-The number of virt-operator pods that are up. Type: Gauge.
-
-### kubevirt_vm_container_memory_request_margin_based_on_rss_bytes
-Difference between requested memory and rss for VM containers (request margin). Can be negative when usage exceeds request. Type: Gauge.
-
-### kubevirt_vm_container_memory_request_margin_based_on_working_set_bytes
-Difference between requested memory and working set for VM containers (request margin). Can be negative when usage exceeds request. Type: Gauge.
-
-### kubevirt_vm_create_date_timestamp_seconds
-Virtual Machine creation timestamp. Type: Gauge.
-
-### kubevirt_vm_created_by_pod_total
-The total number of VMs created by namespace and virt-api pod, since install. Type: Counter.
-
-### kubevirt_vm_created_total
-The total number of VMs created by namespace, since install. Type: Counter.
-
-### kubevirt_vm_disk_allocated_size_bytes
-Allocated disk size of a Virtual Machine in bytes, based on its PersistentVolumeClaim. Includes persistentvolumeclaim (PVC name), volume_mode (disk presentation mode: Filesystem or Block), and device (disk name). Type: Gauge.
-
-### kubevirt_vm_error_status_last_transition_timestamp_seconds
-Virtual Machine last transition timestamp to error status. Type: Counter.
-
-### kubevirt_vm_info
-Information about Virtual Machines. Type: Gauge.
-
-### kubevirt_vm_labels
-The metric exposes the VM labels as Prometheus labels. Configure allowed and ignored labels via the 'kubevirt-vm-labels-config' ConfigMap. Type: Gauge.
-
-### kubevirt_vm_migrating_status_last_transition_timestamp_seconds
-Virtual Machine last transition timestamp to migrating status. Type: Counter.
-
-### kubevirt_vm_non_running_status_last_transition_timestamp_seconds
-Virtual Machine last transition timestamp to paused/stopped status. Type: Counter.
-
-### kubevirt_vm_resource_limits
-Resources limits by Virtual Machine. Reports memory and CPU limits. Type: Gauge.
-
-### kubevirt_vm_resource_requests
-Resources requested by Virtual Machine. Reports memory and CPU requests. Type: Gauge.
-
-### kubevirt_vm_running_status_last_transition_timestamp_seconds
-Virtual Machine last transition timestamp to running status. Type: Counter.
-
-### kubevirt_vm_starting_status_last_transition_timestamp_seconds
-Virtual Machine last transition timestamp to starting status. Type: Counter.
-
-### kubevirt_vm_vnic_info
-Details of Virtual Machine (VM) vNIC interfaces, such as vNIC name, binding type, network name, and binding name for each vNIC defined in the VM's configuration. Type: Gauge.
-
-### kubevirt_vmi_cpu_system_usage_seconds_total
-Total CPU time spent in system mode. Type: Counter.
-
-### kubevirt_vmi_cpu_usage_seconds_total
-Total CPU time spent in all modes (sum of both vcpu and hypervisor usage). Type: Counter.
-
-### kubevirt_vmi_cpu_user_usage_seconds_total
-Total CPU time spent in user mode. Type: Counter.
-
-### kubevirt_vmi_dirty_rate_bytes_per_second
-Guest dirty-rate in bytes per second. Type: Gauge.
-
-### kubevirt_vmi_filesystem_capacity_bytes
-Total VM filesystem capacity in bytes. Type: Gauge.
-
-### kubevirt_vmi_filesystem_used_bytes
-Used VM filesystem capacity in bytes. Type: Gauge.
-
-### kubevirt_vmi_guest_load_15m
-Guest system load average over 15 minutes as reported by the guest agent. Load is defined as the number of processes in the runqueue or waiting for disk I/O. Requires qemu-guest-agent version 10.0.0 or above. Type: Gauge.
-
-### kubevirt_vmi_guest_load_1m
-Guest system load average over 1 minute as reported by the guest agent. Load is defined as the number of processes in the runqueue or waiting for disk I/O. Requires qemu-guest-agent version 10.0.0 or above. Type: Gauge.
-
-### kubevirt_vmi_guest_load_5m
-Guest system load average over 5 minutes as reported by the guest agent. Load is defined as the number of processes in the runqueue or waiting for disk I/O. Requires qemu-guest-agent version 10.0.0 or above. Type: Gauge.
-
-### kubevirt_vmi_guest_vcpu_queue
-Guest queue length. Type: Gauge.
-
-### kubevirt_vmi_info
-Information about VirtualMachineInstances. Type: Gauge.
-
-### kubevirt_vmi_last_api_connection_timestamp_seconds
-Virtual Machine Instance last API connection timestamp. Including VNC, console, portforward, SSH and usbredir connections. Type: Gauge.
-
-### kubevirt_vmi_launcher_memory_overhead_bytes
-Estimation of the memory amount required for virt-launcher's infrastructure components (e.g. libvirt, QEMU). Type: Gauge.
-
-### kubevirt_vmi_memory_actual_balloon_bytes
-Current balloon size in bytes. Type: Gauge.
-
-### kubevirt_vmi_memory_available_bytes
-Amount of usable memory as seen by the domain. This value may not be accurate if a balloon driver is in use or if the guest OS does not initialize all assigned pages Type: Gauge.
-
-### kubevirt_vmi_memory_cached_bytes
-The amount of memory that is being used to cache I/O and is available to be reclaimed, corresponds to the sum of `Buffers` + `Cached` + `SwapCached` in `/proc/meminfo`. Type: Gauge.
-
-### kubevirt_vmi_memory_domain_bytes
-The amount of memory in bytes allocated to the domain. The `memory` value in domain xml file. Type: Gauge.
-
-### kubevirt_vmi_memory_pgmajfault_total
-The number of page faults when disk IO was required. Page faults occur when a process makes a valid access to virtual memory that is not available. When servicing the page fault, if disk IO is required, it is considered as major fault. Type: Counter.
-
-### kubevirt_vmi_memory_pgminfault_total
-The number of other page faults, when disk IO was not required. Page faults occur when a process makes a valid access to virtual memory that is not available. When servicing the page fault, if disk IO is NOT required, it is considered as minor fault. Type: Counter.
-
-### kubevirt_vmi_memory_resident_bytes
-Resident set size of the process running the domain. Type: Gauge.
-
-### kubevirt_vmi_memory_swap_in_traffic_bytes
-The total amount of data read from swap space of the guest in bytes. Type: Gauge.
-
-### kubevirt_vmi_memory_swap_out_traffic_bytes
-The total amount of memory written out to swap space of the guest in bytes. Type: Gauge.
-
-### kubevirt_vmi_memory_unused_bytes
-The amount of memory left completely unused by the system. Memory that is available but used for reclaimable caches should NOT be reported as free. Type: Gauge.
-
-### kubevirt_vmi_memory_usable_bytes
-The amount of memory which can be reclaimed by balloon without pushing the guest system to swap, corresponds to 'Available' in /proc/meminfo. Type: Gauge.
-
-### kubevirt_vmi_memory_used_bytes
-Amount of `used` memory as seen by the domain. Type: Gauge.
-
-### kubevirt_vmi_migration_data_processed_bytes
-The total Guest OS data processed and migrated to the new VM. Type: Gauge.
-
-### kubevirt_vmi_migration_data_remaining_bytes
-The remaining guest OS data to be migrated to the new VM. Type: Gauge.
-
-### kubevirt_vmi_migration_data_total_bytes
-The total Guest OS data to be migrated to the new VM. Type: Counter.
-
-### kubevirt_vmi_migration_dirty_memory_rate_bytes
-The rate of memory being dirty in the Guest OS. Type: Gauge.
-
-### kubevirt_vmi_migration_end_time_seconds
-The time at which the migration ended. Type: Gauge.
-
-### kubevirt_vmi_migration_failed
-Indicates if the VMI migration failed. Type: Gauge.
-
-### kubevirt_vmi_migration_memory_transfer_rate_bytes
-The rate at which the memory is being transferred. Type: Gauge.
-
-### kubevirt_vmi_migration_phase_transition_time_from_creation_seconds
-Histogram of VM migration phase transitions duration from creation time in seconds. Type: Histogram.
-
-### kubevirt_vmi_migration_start_time_seconds
-The time at which the migration started. Type: Gauge.
-
-### kubevirt_vmi_migration_succeeded
-Indicates if the VMI migration succeeded. Type: Gauge.
-
-### kubevirt_vmi_migrations_in_pending_phase
-Number of current pending migrations. Type: Gauge.
-
-### kubevirt_vmi_migrations_in_running_phase
-Number of current running migrations. Type: Gauge.
-
-### kubevirt_vmi_migrations_in_scheduling_phase
-Number of current scheduling migrations. Type: Gauge.
-
-### kubevirt_vmi_migrations_in_unset_phase
-Number of current unset migrations. These are pending items the virt-controller hasn’t processed yet from the queue. Type: Gauge.
-
-### kubevirt_vmi_network_receive_bytes_total
-Total network traffic received in bytes. Type: Counter.
-
-### kubevirt_vmi_network_receive_errors_total
-Total network received error packets. Type: Counter.
-
-### kubevirt_vmi_network_receive_packets_dropped_total
-The total number of rx packets dropped on vNIC interfaces. Type: Counter.
-
-### kubevirt_vmi_network_receive_packets_total
-Total network traffic received packets. Type: Counter.
-
-### kubevirt_vmi_network_traffic_bytes_total
-[Deprecated] Total number of bytes sent and received. Type: Counter.
-
-### kubevirt_vmi_network_transmit_bytes_total
-Total network traffic transmitted in bytes. Type: Counter.
-
-### kubevirt_vmi_network_transmit_errors_total
-Total network transmitted error packets. Type: Counter.
-
-### kubevirt_vmi_network_transmit_packets_dropped_total
-The total number of tx packets dropped on vNIC interfaces. Type: Counter.
-
-### kubevirt_vmi_network_transmit_packets_total
-Total network traffic transmitted packets. Type: Counter.
-
-### kubevirt_vmi_node_cpu_affinity
-Number of VMI CPU affinities to node physical cores. Type: Gauge.
-
-### kubevirt_vmi_non_evictable
-Indication for a VirtualMachine that its eviction strategy is set to Live Migration but is not migratable. Type: Gauge.
-
-### kubevirt_vmi_number_of_outdated
-Indication for the total number of VirtualMachineInstance workloads that are not running within the most up-to-date version of the virt-launcher environment. Type: Gauge.
-
-### kubevirt_vmi_phase_count
-Sum of VMIs per phase and node. `phase` can be one of the following: [`Pending`, `Scheduling`, `Scheduled`, `Running`, `Succeeded`, `Failed`, `Unknown`]. Type: Gauge.
-
-### kubevirt_vmi_phase_transition_time_from_creation_seconds
-Histogram of VM phase transitions duration from creation time in seconds. Type: Histogram.
-
-### kubevirt_vmi_phase_transition_time_from_deletion_seconds
-Histogram of VM phase transitions duration from deletion time in seconds. Type: Histogram.
-
-### kubevirt_vmi_phase_transition_time_seconds
-Histogram of VM phase transitions duration between different phases in seconds. Type: Histogram.
-
-### kubevirt_vmi_status_addresses
-The addresses of a VirtualMachineInstance. This metric provides the address of an available network interface associated with the VMI in the 'address' label, and about the type of address, such as internal IP, in the 'type' label. Type: Gauge.
-
-### kubevirt_vmi_storage_flush_requests_total
-Total storage flush requests. Type: Counter.
-
-### kubevirt_vmi_storage_flush_times_seconds_total
-Total time spent on cache flushing. Type: Counter.
-
-### kubevirt_vmi_storage_iops_read_total
-Total number of I/O read operations. Type: Counter.
-
-### kubevirt_vmi_storage_iops_write_total
-Total number of I/O write operations. Type: Counter.
-
-### kubevirt_vmi_storage_read_times_seconds_total
-Total time spent on read operations. Type: Counter.
-
-### kubevirt_vmi_storage_read_traffic_bytes_total
-Total number of bytes read from storage. Type: Counter.
-
-### kubevirt_vmi_storage_write_times_seconds_total
-Total time spent on write operations. Type: Counter.
-
-### kubevirt_vmi_storage_write_traffic_bytes_total
-Total number of written bytes. Type: Counter.
-
-### kubevirt_vmi_vcpu_delay_seconds_total
-Amount of time spent by each vcpu waiting in the queue instead of running. Type: Counter.
-
-### kubevirt_vmi_vcpu_seconds_total
-Total amount of time spent in each state by each vcpu (cpu_time excluding hypervisor time). Where `id` is the vcpu identifier and `state` can be one of the following: [`OFFLINE`, `RUNNING`, `BLOCKED`]. Type: Counter.
-
-### kubevirt_vmi_vcpu_wait_seconds_total
-Amount of time spent by each vcpu while waiting on I/O. Type: Counter.
-
-### kubevirt_vmi_vnic_info
-Details of VirtualMachineInstance (VMI) vNIC interfaces, such as vNIC name, binding type, network name, and binding name for each vNIC of a running instance. Type: Gauge.
-
-### kubevirt_vmsnapshot_disks_restored_from_source
-Returns the total number of virtual machine disks restored from the source virtual machine. Type: Gauge.
-
-### kubevirt_vmsnapshot_disks_restored_from_source_bytes
-Returns the amount of space in bytes restored from the source virtual machine. Type: Gauge.
-
-### kubevirt_vmsnapshot_persistentvolumeclaim_labels
-Returns the labels of the persistent volume claims that are used for restoring virtual machines. Type: Gauge.
-
-### kubevirt_vmsnapshot_succeeded_timestamp_seconds
-Returns the timestamp of successful virtual machine snapshot. Type: Gauge.
-
-### kubevirt_vnc_active_connections
-Amount of active VNC connections, broken down by namespace and vmi name. Type: Gauge.
-
-### kubevirt_workqueue_adds_total
-Total number of adds handled by workqueue Type: Counter.
-
-### kubevirt_workqueue_depth
-Current depth of workqueue Type: Gauge.
-
-### kubevirt_workqueue_longest_running_processor_seconds
-How many seconds has the longest running processor for workqueue been running. Type: Gauge.
-
-### kubevirt_workqueue_queue_duration_seconds
-How long an item stays in workqueue before being requested. Type: Histogram.
-
-### kubevirt_workqueue_retries_total
-Total number of retries handled by workqueue Type: Counter.
-
-### kubevirt_workqueue_unfinished_work_seconds
-How many seconds of work has done that is in progress and hasn't been observed by work_duration. Large values indicate stuck threads. One can deduce the number of stuck threads by observing the rate at which this increases. Type: Gauge.
-
-### kubevirt_workqueue_work_duration_seconds
-How long in seconds processing an item from workqueue takes. Type: Histogram.
-
-### vmi:kubevirt_vmi_vcpu:count
-The number of the VMI vCPUs. Type: Gauge.
-
-<div id='containerized-data-importer'></div>
-
-## [containerized-data-importer](https://github.com/kubevirt/containerized-data-importer/tree/main)
-
-### kubevirt_cdi_clone_pods_high_restart
-The number of CDI clone pods with high restart count. Type: Gauge.
-
-### kubevirt_cdi_clone_progress_total
-The clone progress in percentage. Type: Counter.
-
-### kubevirt_cdi_cr_ready
-CDI install ready. Type: Gauge.
-
-### kubevirt_cdi_dataimportcron_outdated
-DataImportCron has an outdated import. Type: Gauge.
-
-### kubevirt_cdi_datavolume_pending
-Number of DataVolumes pending for default storage class to be configured. Type: Gauge.
-
-### kubevirt_cdi_import_pods_high_restart
-The number of CDI import pods with high restart count. Type: Gauge.
-
-### kubevirt_cdi_import_progress_total
-The import progress in percentage. Type: Counter.
-
-### kubevirt_cdi_openstack_populator_progress_total
-Progress of volume population. Type: Counter.
-
-### kubevirt_cdi_operator_up
-CDI operator status. Type: Gauge.
-
-### kubevirt_cdi_ovirt_progress_total
-Progress of volume population. Type: Counter.
-
-### kubevirt_cdi_storageprofile_info
-`StorageProfiles` info labels: `storageclass`, `provisioner`, `complete` indicates if all storage profiles recommended PVC settings are complete, `default` indicates if it's the Kubernetes default storage class, `virtdefault` indicates if it's the default virtualization storage class, `rwx` indicates if the storage class supports `ReadWriteMany`, `smartclone` indicates if it supports snapshot or CSI based clone, `degraded` indicates it is not optimal for virtualization. Type: Gauge.
-
-### kubevirt_cdi_upload_pods_high_restart
-The number of CDI upload server pods with high restart count. Type: Gauge.
-
-<div id='cluster-network-addons-operator'></div>
-
-## [cluster-network-addons-operator](https://github.com/kubevirt/cluster-network-addons-operator/tree/main)
-
-### kubevirt_cnao_cr_kubemacpool_aggregated
-Total count of KubeMacPool manager pods deployed by CNAO CR. Type: Gauge.
-
-### kubevirt_cnao_cr_kubemacpool_deployed
-KubeMacpool is deployed by CNAO CR. Type: Gauge.
-
-### kubevirt_cnao_cr_ready
-CNAO CR Ready. Type: Gauge.
-
-### kubevirt_cnao_kubemacpool_duplicate_macs
-Total count of duplicate KubeMacPool MAC addresses. Type: Gauge.
-
-### kubevirt_cnao_kubemacpool_manager_up
-Total count of running KubeMacPool manager pods. Type: Gauge.
-
-### kubevirt_cnao_operator_up
-Total count of running CNAO operators. Type: Gauge.
-
-<div id='ssp-operator'></div>
-
-## [ssp-operator](https://github.com/kubevirt/ssp-operator/tree/main)
-
-### cnv:vmi_status_running:count
-The total number of running VMIs, labeled with node, instance type, preference and guest OS information. Type: Gauge.
-
-### kubevirt_ssp_common_templates_restored_increase
-The increase in the number of common templates restored by the operator back to their original state, over the last hour. Type: Gauge.
-
-### kubevirt_ssp_common_templates_restored_total
-The total number of common templates restored by the operator back to their original state. Type: Counter.
-
-### kubevirt_ssp_operator_reconcile_succeeded
-Set to 1 if the reconcile process of all operands completes with no errors, and to 0 otherwise. Type: Gauge.
-
-### kubevirt_ssp_operator_reconcile_succeeded_aggregated
-The total number of ssp-operator pods reconciling with no errors. Type: Gauge.
-
-### kubevirt_ssp_operator_up
-The total number of running ssp-operator pods. Type: Gauge.
-
-### kubevirt_ssp_template_validator_rejected_increase
-The increase in the number of rejected template validators, over the last hour. Type: Gauge.
-
-### kubevirt_ssp_template_validator_rejected_total
-The total number of rejected template validators. Type: Counter.
-
-### kubevirt_ssp_template_validator_up
-The total number of running virt-template-validator pods. Type: Gauge.
-
-### kubevirt_ssp_vm_rbd_block_volume_without_rxbounce
-[ALPHA] VM with RBD mounted Block volume (without rxbounce option set). Type: Gauge.
-
-<div id='hostpath-provisioner-operator'></div>
-
-## [hostpath-provisioner-operator](https://github.com/kubevirt/hostpath-provisioner-operator/tree/main)
-
-### kubevirt_hpp_cr_ready
-HPP CR Ready. Type: Gauge.
-
-### kubevirt_hpp_operator_up
-The number of running hostpath-provisioner-operator pods. Type: Gauge.
-
-<div id='hostpath-provisioner'></div>
-
-## [hostpath-provisioner](https://github.com/kubevirt/hostpath-provisioner/tree/main)
-
-### kubevirt_hpp_pool_path_shared_with_os
-HPP pool path sharing a filesystem with OS, fix to prevent HPP PVs from causing disk pressure and affecting node operation. Type: Gauge.
-
-<div id='hyperconverged-cluster-operator'></div>
-
-## [hyperconverged-cluster-operator](https://github.com/kubevirt/hyperconverged-cluster-operator/tree/main)
-
-### cluster:vmi_request_cpu_cores:sum
-Sum of CPU core requests for all running virt-launcher VMIs across the entire Kubevirt cluster. Type: Gauge.
-
-### cnv_abnormal
-Monitors resources for potential problems. Type: Gauge.
-
-### kubevirt_hco_dataimportcrontemplate_with_architecture_annotation
-Indicates whether the DataImportCronTemplate has the ssp.kubevirt.io/dict.architectures annotation (0) or not (1). Type: Gauge.
-
-### kubevirt_hco_dataimportcrontemplate_with_supported_architectures
-Indicates whether the DataImportCronTemplate has supported architectures (0) or not (1). Type: Gauge.
-
-### kubevirt_hco_hyperconverged_cr_exists
-Indicates whether the HyperConverged custom resource exists (1) or not (0). Type: Gauge.
-
-### kubevirt_hco_memory_overcommit_percentage
-Indicates the cluster-wide configured VM memory overcommit percentage. Type: Gauge.
-
-### kubevirt_hco_misconfigured_descheduler
-Indicates whether the optional descheduler is not properly configured (1) to work with KubeVirt or not (0). Type: Gauge.
-
-### kubevirt_hco_out_of_band_modifications_total
-Count of out-of-band modifications overwritten by HCO. Type: Counter.
-
-### kubevirt_hco_single_stack_ipv6
-Indicates whether the underlying cluster is single stack IPv6 (1) or not (0). Type: Gauge.
-
-### kubevirt_hco_system_health_status
-Indicates whether the system health status is healthy (0), warning (1), or error (2), by aggregating the conditions of HCO and its secondary resources. Type: Gauge.
-
-### kubevirt_hco_unsafe_modifications
-Count of unsafe modifications in the HyperConverged annotations. Type: Gauge.
-
-### kubevirt_hyperconverged_operator_health_status
-Indicates whether HCO and its secondary resources health status is healthy (0), warning (1) or critical (2), based both on the firing alerts that impact the operator health, and on kubevirt_hco_system_health_status metric. Type: Gauge.
 

--- a/tools/metricsdocs/metrics.tmpl
+++ b/tools/metricsdocs/metrics.tmpl
@@ -1,0 +1,22 @@
+# KubeVirt components metrics
+
+This document aims to help users that are not familiar with metrics exposed by all the KubeVirt components.
+All metrics documented here are auto-generated in each component repository and gathered here.
+They reflect and describe exactly what is being exposed.
+
+## Operator Repositories
+
+| Operator Name |
+|---------------|
+{{range .Operators}}| {{.Link}} |
+{{end}}
+
+## Metrics
+
+The following table contains all metrics from operators listed above. Each row represents a single metric with its operator, name, type (Gauge, Counter, Histogram, etc.), and description.
+
+| Operator Name | Metric Name | Type | Description |
+|----------|------|------|-------------|
+{{range .Metrics}}| {{.Operator | escapePipe}} | {{.Name | codeSpan}} | {{.Type | escapePipe}} | {{.Description | normalizeDescription}} |
+{{end}}
+

--- a/tools/metricsdocs/metricsdocs.go
+++ b/tools/metricsdocs/metricsdocs.go
@@ -21,16 +21,48 @@ package main
 
 import (
 	"bufio"
+	_ "embed"
 	"flag"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"path"
+	"sort"
 	"strings"
+	"text/template"
 
 	"github.com/joho/godotenv"
 )
+
+//go:embed metrics.tmpl
+var metricsTemplate string
+
+var (
+	metricsTmpl *template.Template
+)
+
+func init() {
+	var err error
+	metricsTmpl, err = template.New("metrics").Funcs(template.FuncMap{
+		"escapePipe": func(s string) string {
+			return strings.ReplaceAll(s, "|", "\\|")
+		},
+		"normalizeDescription": func(s string) string {
+			s = strings.ReplaceAll(s, "|", "\\|")
+			s = strings.ReplaceAll(s, "\n", " ")
+			return strings.TrimSpace(s)
+		},
+		"codeSpan": func(s string) string {
+			s = strings.ReplaceAll(s, "`", "\\`")
+			s = strings.ReplaceAll(s, "|", "\\|")
+			return "`" + s + "`"
+		},
+	}).Parse(metricsTemplate)
+	if err != nil {
+		log.Fatalf("ERROR: parsing metrics template: %s", err)
+	}
+}
 
 func main() {
 	r := parseArguments()
@@ -61,21 +93,21 @@ func createProjects(configFile string, baseDir string, org string) []*project {
 	config := getConfig(configFile)
 
 	var projects []*project
-	for _, n := range projectsInfo {
-		version, ok := config[n.short+"_VERSION"]
+	for _, info := range projectsInfo {
+		version, ok := config[info.short+"_VERSION"]
 
 		if !ok {
-			log.Fatalf("ERROR: config doesn't contain '%s_VERSION' for %s", n.short, n.name)
+			log.Fatalf("ERROR: config doesn't contain '%s_VERSION' for %s", info.short, info.name)
 		}
 
 		projects = append(projects, &project{
-			short:   n.short,
-			name:    n.name,
+			short:   info.short,
+			name:    info.name,
 			version: version,
 
-			repoDir:        baseDir + n.name,
-			repoUrl:        fmt.Sprintf("https://github.com/%s/%s.git", org, n.name),
-			metricsDocPath: n.metricsDocPath,
+			repoDir:        baseDir + info.name,
+			repoUrl:        fmt.Sprintf("https://github.com/%s/%s.git", org, info.name),
+			metricsDocPath: info.metricsDocPath,
 		})
 	}
 
@@ -108,11 +140,8 @@ func (r *releaseData) createDoc() {
 	r.outFile = createFile()
 	defer r.outFile.Close()
 
-	r.writeHeader()
-
 	metrics := r.parseMetrics()
 
-	r.writeTOC(metrics)
 	r.writeMetrics(metrics)
 }
 
@@ -124,15 +153,8 @@ func createFile() *os.File {
 	return file
 }
 
-func (r *releaseData) writeHeader() {
-	r.outFile.WriteString("# KubeVirt components metrics\n\n")
-	r.outFile.WriteString("This document aims to help users that are not familiar with metrics exposed by all the KubeVirt components.\n")
-	r.outFile.WriteString("All metrics documented here are auto-generated in each component repository and gathered here.\n")
-	r.outFile.WriteString("They reflect and describe exactly what is being exposed.\n\n")
-}
-
-func (r *releaseData) parseMetrics() map[string]string {
-	metrics := make(map[string]string)
+func (r *releaseData) parseMetrics() []Metric {
+	var metrics []Metric
 
 	for _, p := range r.projects {
 		content, err := readLines(path.Join(p.repoDir, "/", p.metricsDocPath))
@@ -141,9 +163,9 @@ func (r *releaseData) parseMetrics() map[string]string {
 			continue
 		}
 
-		parsed := p.parseMetricsDoc(content)
+		parsed := p.parseMetricsDoc(content, p.name)
 		if len(parsed) != 0 {
-			metrics[p.name] = parsed
+			metrics = append(metrics, parsed...)
 		} else {
 			log.Printf("WARNING: %s project metrics documentation file is empty in '%s'", p.name, p.version)
 		}
@@ -152,38 +174,85 @@ func (r *releaseData) parseMetrics() map[string]string {
 	return metrics
 }
 
-func (r *releaseData) writeTOC(metrics map[string]string) {
-	r.outFile.WriteString("## Table of Contents\n\n")
+func (r *releaseData) writeMetrics(metrics []Metric) {
+	sortMetrics(metrics)
 
-	for _, p := range r.projects {
-		if _, ok := metrics[p.name]; ok {
-			r.outFile.WriteString("- [" + p.name + "](#" + p.name + ")\n")
-		}
+	templateData := struct {
+		Operators []TemplateOperator
+		Metrics   []Metric
+	}{
+		Operators: r.buildOperators(getOperatorOrder(metrics)),
+		Metrics:   metrics,
 	}
 
-	r.outFile.WriteString("\n")
-}
-
-func (r *releaseData) writeMetrics(metrics map[string]string) {
-	for _, p := range r.projects {
-		if content, ok := metrics[p.name]; ok {
-			p.writeComponentMetrics(r.outFile, content)
-		}
+	if err := metricsTmpl.Execute(r.outFile, templateData); err != nil {
+		log.Printf("ERROR: executing metrics template: %s", err)
 	}
 }
 
-func (p *project) writeComponentMetrics(outFile *os.File, content string) {
-	outFile.WriteString("<div id='" + p.name + "'></div>\n\n")
+func sortMetrics(metrics []Metric) {
+	sort.SliceStable(metrics, func(i, j int) bool {
+		if metrics[i].Operator != metrics[j].Operator {
+			if metrics[i].Operator == "kubevirt" {
+				return true
+			}
+			if metrics[j].Operator == "kubevirt" {
+				return false
+			}
+			return metrics[i].Operator < metrics[j].Operator
+		}
+		return metrics[i].Name < metrics[j].Name
+	})
+}
 
+func getOperatorOrder(metrics []Metric) []string {
+	seen := make(map[string]bool)
+	var operatorOrder []string
+	for _, m := range metrics {
+		if !seen[m.Operator] {
+			operatorOrder = append(operatorOrder, m.Operator)
+			seen[m.Operator] = true
+		}
+	}
+	return operatorOrder
+}
+
+func (r *releaseData) buildOperators(operatorOrder []string) []TemplateOperator {
+	operatorLinkMap := make(map[string]string)
+	seenOperators := make(map[string]bool)
+	for _, opName := range operatorOrder {
+		seenOperators[opName] = true
+	}
+
+	for _, p := range r.projects {
+		if seenOperators[p.name] {
+			operatorLinkMap[p.name] = p.writeComponentMetrics()
+		}
+	}
+
+	var operators []TemplateOperator
+	for _, opName := range operatorOrder {
+		if link, ok := operatorLinkMap[opName]; ok {
+			operators = append(operators, TemplateOperator{
+				Name: opName,
+				Link: link,
+			})
+		}
+	}
+	return operators
+}
+
+func (p *project) writeComponentMetrics() string {
 	resp, err := http.Get(fmt.Sprintf("https://api.github.com/repos/kubevirt/%s/releases/tags/%s", p.name, p.version))
 
-	if err != nil || resp.StatusCode != 200 {
-		outFile.WriteString(fmt.Sprintf("## [%s](https://github.com/kubevirt/%s/tree/%s)\n\n", p.name, p.name, p.version))
-	} else {
-		outFile.WriteString(fmt.Sprintf("## [%s - %s](https://github.com/kubevirt/%s/releases/tag/%s)\n\n", p.name, p.version, p.name, p.version))
+	if err == nil {
+		defer resp.Body.Close()
 	}
 
-	outFile.WriteString(content)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return fmt.Sprintf("[%s](https://github.com/kubevirt/%s/tree/%s)", p.name, p.name, p.version)
+	}
+	return fmt.Sprintf("[%s - %s](https://github.com/kubevirt/%s/releases/tag/%s)", p.name, p.version, p.name, p.version)
 }
 
 func readLines(path string) ([]string, error) {
@@ -201,23 +270,94 @@ func readLines(path string) ([]string, error) {
 	return lines, scanner.Err()
 }
 
-func (p *project) parseMetricsDoc(content []string) string {
-	running := false
-	var b strings.Builder
+func (p *project) parseMetricsDoc(content []string, operatorName string) []Metric {
+	var metrics []Metric
+	var currentMetric *Metric
+	inMetricsSection := false
 
-	for _, s := range content {
-		if !running && isBeginning(s) {
-			running = true
-			fmt.Fprintln(&b, s)
-		} else if running {
-			if isEnd(s) {
+	for i, line := range content {
+		if isBeginning(line) {
+			metrics, currentMetric = p.handleMetricBeginning(metrics, currentMetric, line, operatorName)
+			inMetricsSection = true
+		} else if inMetricsSection {
+			if isEnd(line) {
+				metrics = p.appendMetricIfValid(metrics, currentMetric)
 				break
 			}
-			fmt.Fprintln(&b, s)
+
+			if currentMetric != nil {
+				metrics, currentMetric = p.processMetricLine(metrics, currentMetric, line, content, i)
+			}
 		}
 	}
 
-	return b.String()
+	return p.appendMetricIfValid(metrics, currentMetric)
+}
+
+func (p *project) handleMetricBeginning(metrics []Metric, currentMetric *Metric, line, operatorName string) ([]Metric, *Metric) {
+	metrics = p.appendMetricIfValid(metrics, currentMetric)
+	metricName := strings.TrimSpace(strings.TrimPrefix(line, "### "))
+	return metrics, &Metric{
+		Operator:    operatorName,
+		Name:        metricName,
+		Type:        "",
+		Description: "",
+	}
+}
+
+func (p *project) processMetricLine(metrics []Metric, currentMetric *Metric, line string, content []string, lineIndex int) ([]Metric, *Metric) {
+	trimmedLine := strings.TrimSpace(line)
+	if trimmedLine == "" {
+		if lineIndex+1 < len(content) && isBeginning(content[lineIndex+1]) {
+			metrics = p.appendMetricIfValid(metrics, currentMetric)
+			return metrics, nil
+		}
+		return metrics, currentMetric
+	}
+
+	if strings.Contains(trimmedLine, "Type:") {
+		return p.parseTypeLine(metrics, currentMetric, trimmedLine)
+	}
+
+	p.appendToDescription(currentMetric, trimmedLine)
+	return metrics, currentMetric
+}
+
+func (p *project) parseTypeLine(metrics []Metric, currentMetric *Metric, line string) ([]Metric, *Metric) {
+	parts := strings.SplitN(line, "Type:", 2)
+	if len(parts) != 2 {
+		p.appendToDescription(currentMetric, line)
+		return metrics, currentMetric
+	}
+
+	desc := strings.TrimSuffix(strings.TrimSpace(parts[0]), ".")
+	p.appendToDescription(currentMetric, desc)
+
+	typePart := strings.TrimSuffix(strings.TrimSpace(parts[1]), ".")
+	currentMetric.Type = typePart
+
+	metrics = p.appendMetricIfValid(metrics, currentMetric)
+	return metrics, nil
+}
+
+func (p *project) appendToDescription(m *Metric, text string) {
+	if m.Description != "" {
+		m.Description += " " + text
+	} else {
+		m.Description = text
+	}
+}
+
+func (p *project) appendMetricIfValid(metrics []Metric, m *Metric) []Metric {
+	if m != nil && m.Name != "" {
+		p.finalizeMetric(m)
+		return append(metrics, *m)
+	}
+	return metrics
+}
+
+func (p *project) finalizeMetric(m *Metric) {
+	m.Description = strings.TrimSpace(m.Description)
 }
 
 func isBeginning(s string) bool {

--- a/tools/metricsdocs/types.go
+++ b/tools/metricsdocs/types.go
@@ -50,6 +50,18 @@ type project struct {
 	metricsDocPath string
 }
 
+type Metric struct {
+	Operator    string
+	Name        string
+	Type        string
+	Description string
+}
+
+type TemplateOperator struct {
+	Name string
+	Link string
+}
+
 type releaseData struct {
 	org      string
 	projects []*project


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Converts the metrics documentation from a header-based format to a unified table-based format.
It introduces:

A table with links to operators repositories 

A table with columns for operator name, metric name, metric type, and description

The new structure is significantly easier to read, compare, and maintain

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered


**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://issues.redhat.com/browse/CNV-24891

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
