### PR TITLE
Add runbook for VirtLauncherPodsStuckFailed alert

### DIFF
--- a/docs/runbooks/VirtLauncherPodsStuckFailed.md
+++ b/docs/runbooks/VirtLauncherPodsStuckFailed.md
@@ -1,0 +1,118 @@
+# VirtLauncherPodsStuckFailed
+
+## Meaning
+
+This alert fires when a large number of virt-launcher Pods remain in Failed phase.
+
+Condition: `cluster:kubevirt_virt_launcher_failed:count >= 200` for 10 minutes
+Virt-launcher Pods host VM workloads and mass failures can indicate migration loops,
+image/network/storage issues, or control-plane regressions.
+
+## Impact
+
+VMs and the cluster control plane may be affected:
+
+- API server and etcd pressure (large object lists/watches, increased latency)
+- Controller and scheduler slowdown (reconciliation over huge Pod sets)
+- Monitoring cardinality spikes (kube-state-metrics and Prometheus load)
+- Operational churn (re-creation loops, CNI and storage attach/detach)
+- Triage noise and SLO risk (timeouts on list operations, noisy dashboards)
+
+## Diagnosis
+
+1. Confirm scope and distribution:
+
+```promql
+cluster:kubevirt_virt_launcher_failed:count
+```
+```promql
+count by (namespace) (kube_pod_status_phase{phase="Failed", pod=~"virt-launcher-.*"} == 1)
+```
+```promql
+count by (node) (
+  (kube_pod_status_phase{phase="Failed", pod=~"virt-launcher-.*"} == 1)
+  * on(pod) group_left(node) kube_pod_info{pod=~"virt-launcher-.*", node!=""}
+)
+```
+```promql
+topk(5, count by (reason) (kube_pod_container_status_last_terminated_reason{pod=~"virt-launcher-.*"} == 1))
+```
+
+2. Sample failed Pods and events:
+
+```bash
+# List a few failed virt-launcher pods cluster-wide
+kubectl get pods -A -l kubevirt.io=virt-launcher --field-selector=status.phase=Failed --no-headers | head -n 20
+```
+```bash
+# Inspect events for a representative pod (image/CNI/storage/useful errors)
+kubectl -n <namespace> describe pod <virt-launcher-pod> | sed -n '/Events/,$p'
+```
+
+3. Check for migration storms:
+
+```bash
+kubectl get vmim -A
+```
+
+4. Control plane and component logs (look for spikes/errors):
+
+```bash
+NAMESPACE="$(kubectl get kubevirt -A -o jsonpath='{.items[0].metadata.namespace}')"
+```
+```bash
+kubectl -n "$NAMESPACE" logs -l kubevirt.io=virt-controller --tail=200
+```
+```bash
+kubectl -n "$NAMESPACE" logs -l kubevirt.io=virt-handler --tail=200
+```
+
+5. Infrastructure checks (common causes):
+
+- Image pulls: registry reachability/credentials; ImagePullBackOff events
+- Network: CNI errors/timeouts in Pod events and node logs
+- Storage: volume attach/mount errors in Pod events and CSI logs
+
+## Mitigation
+
+1. Reduce blast radius:
+
+- Migration loop: cancel in-flight migrations (scope as needed)
+
+```bash
+kubectl delete vmim -A
+```
+
+- Coordinate with noisy tenants; pause offending workloads if necessary.
+
+2. Clean up Failed Pods (relieves API/etcd and monitoring):
+
+```bash
+kubectl get pods -A -l kubevirt.io=virt-launcher --field-selector=status.phase=Failed -o name | xargs -r -n50 kubectl delete
+```
+
+3. Resolve root cause:
+
+- Image issues: fix registry access, credentials, or tags; re-run affected workloads.
+- Network/CNI: fix CNI/data-plane errors; confirm new Pods start cleanly.
+- Storage: resolve attach/mount failures; verify PVC/VolumeSnapshot health.
+- KubeVirt regression: roll forward/back to a known-good version and re-try.
+
+4. Validate resolution (alert clears):
+
+```promql
+cluster:kubevirt_virt_launcher_failed:count
+```
+
+Ensure the failed count drops and stays below threshold
+and that new virt-launcher Pods start successfully and VMIs are healthy.
+
+<!--DS: If you cannot resolve the issue, log in to the
+link:https://access.redhat.com[Customer Portal] and open a support case,
+attaching the artifacts gathered during the diagnosis procedure.-->
+<!--USstart-->
+If you cannot resolve the issue, see the following resources:
+
+- [OKD Help](https://okd.io/docs/community/help/)
+- [#virtualization Slack channel](https://kubernetes.slack.com/channels/virtualization)
+<!--USend-->


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adds a runbook for VirtLauncherPodsStuckFailed alert

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://issues.redhat.com/browse/CNV-74773

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
