### PR TITLE
Update KubeVirtVMGuestMemoryAvailableLow alert runbook

### DIFF
--- a/docs/runbooks/KubeVirtVMGuestMemoryAvailableLow.md
+++ b/docs/runbooks/KubeVirtVMGuestMemoryAvailableLow.md
@@ -62,6 +62,26 @@ extended period with no meaningful swap I/O, approaching OOM conditions.
 
 - Increase VM memory (hotplug if supported; otherwise restart may be required)
 
+To increase VM memory in the VM spec:
+
+  ```bash
+  # Edit the VM and adjust spec.template.spec.domain.resources.{requests,limits}.memory
+  kubectl edit vm <vm-name> -n <namespace>
+  ```
+
+If a restart is required to apply the change, gracefully stop the VM when appropriate:
+
+  ```bash
+  # Stop the VM (you can start it again from your usual workflow)
+  virtctl stop <vm-name> -n <namespace>
+  ```
+
+Start the VM after updating the memory:
+
+  ```bash
+  virtctl start <vm-name> -n <namespace>
+  ```
+
 <!--DS: If you cannot resolve the issue, log in to the
 link:https://access.redhat.com[Customer Portal] and open a support case,
 attaching the artifacts gathered during the diagnosis procedure.-->


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
