### PR TITLE
Add CodeRabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -38,6 +38,7 @@ reviews:
   enable_prompt_for_ai_agents: true
   path_filters:
     - "!**/vendor/**"
+    - "!go.sum"
   path_instructions:
     - path: "docs/runbooks/**"
       instructions: "Follow docs/review_guidelines/runbooks.md"
@@ -45,6 +46,8 @@ reviews:
       instructions: "Follow docs/review_guidelines/docs.md"
     - path: "dashboards/**"
       instructions: "Follow docs/review_guidelines/dashboards.md"
+    - path: "**/*.go"
+      instructions: "Follow docs/review_guidelines/go.md"
   abort_on_close: true
   disable_cache: false
   slop_detection:

--- a/docs/review_guidelines/dashboards.md
+++ b/docs/review_guidelines/dashboards.md
@@ -2,6 +2,8 @@
 
 Applies to: `dashboards/**`
 
+## Grafana dashboards (`dashboards/grafana/`)
+
 - Verify that PromQL queries reference valid metrics or recording rules
   from `docs/metrics.md`, the kubevirt operator source repositories, or
   standard Kubernetes/Prometheus ecosystem metrics.
@@ -10,3 +12,23 @@ Applies to: `dashboards/**`
   and match Kubernetes label conventions.
 - Review Grafana JSON for proper formatting and no hardcoded values
   (namespaces, cluster names, etc.).
+
+## Perses dashboards (`dashboards/perses/`)
+
+Perses dashboard YAMLs are **generated artifacts** produced by
+`cmd/generate-perses-dashboards/`. Do not review PromQL or panel
+logic in the YAML files — review the Go builder code instead.
+
+When reviewing changes to generated Perses dashboards:
+
+- Confirm `make verify-perses-dashboards` passes (CI checks this).
+- Review the Go source in `cmd/generate-perses-dashboards/` and
+  `pkg/dashboards/` for correctness, not the YAML output.
+- For multicluster builders (imported from MCOA), PromQL logic
+  is owned upstream — only review the transform layer in
+  `pkg/dashboards/transform/`.
+- For local builders (`multicluster: false`), review the builder
+  function for correct PromQL, variables, and panel structure.
+- Verify that new dashboards are added to the `builders` slice
+  in `cmd/generate-perses-dashboards/main.go` with the correct
+  `multicluster` flag.

--- a/docs/review_guidelines/go.md
+++ b/docs/review_guidelines/go.md
@@ -1,0 +1,12 @@
+# Go Review Guidelines
+
+Applies to: `**/*.go`
+
+- Keep functions short and focused. ~30 lines is a directional
+  guideline, not a hard limit — test helpers and generated code
+  are exempt.
+- Each function should do one thing. Prefer named helper functions
+  over inline anonymous functions, but short idiomatic closures
+  (e.g. `go func` callbacks under ~10 lines) are fine.
+- Flag functions that are long or complex enough to harm
+  readability for someone unfamiliar with the codebase.


### PR DESCRIPTION
Add `.coderabbit.yaml` with:

- Path filters to skip review of generated
  dashboard YAMLs (`dashboards/perses/**`)
  and `go.sum`
- Review instruction for Go files to flag
  functions that are too long and should be
  split into smaller, focused helpers

Signed-off-by: Shirly Radco <sradco@redhat.com>
Co-authored-by: AI Assistant <noreply@cursor.com>

Made with [Cursor](https://cursor.com)