### PR TITLE
Fix CPU unit in top consumers dashboard from percent to cores

### DIFF
--- a/dashboards/openshift/kubevirt-top-consumers.json
+++ b/dashboards/openshift/kubevirt-top-consumers.json
@@ -288,7 +288,7 @@
           "unit": "short"
         },
         {
-          "alias": "CPU Usage",
+          "alias": "CPU Usage (cores)",
           "colorMode": null,
           "colors": [],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
@@ -300,7 +300,7 @@
           "pattern": "Value #A",
           "thresholds": [],
           "type": "number",
-          "unit": "percentunit"
+          "unit": "short"
         },
         {
           "alias": "",
@@ -1386,8 +1386,8 @@
       "yaxes": [
         {
           "decimals": 2,
-          "format": "s",
-          "label": null,
+          "format": "short",
+          "label": "cores",
           "logBase": 1,
           "max": null,
           "min": 0,


### PR DESCRIPTION
## Summary

- Changed the "Top Consumers of CPU by virt-launcher Pods" table panel unit from `percentunit` to `short` (cores) and renamed the column alias to "CPU Usage (cores)"
- Fixed the "CPU Usage by virt-launcher Pods" time-series graph y-axis from `s` (seconds) to `short` with a "cores" label

## Problem

The query `rate(container_cpu_usage_seconds_total{container="compute",pod=~"virt-launcher-.*"})` returns CPU usage in **cores** (seconds/second), but the panel was formatting the value as a percentage. A pod using 2 out of 8 assigned CPUs was displayed as "200%" instead of "2 cores".

## Test plan

- [ ] Open Observe > Dashboards > "KubeVirt / Infrastructure Resources / Top Consumers"
- [ ] Verify "Top Consumers of CPU by virt-launcher Pods" table shows values in cores (e.g. `2.00`) not percent (e.g. `200%`)
- [ ] Verify "CPU Usage by virt-launcher Pods" time-series graph y-axis is labeled "cores" with correct numeric values
- [ ] Confirm values align with the overview dashboard (CNV-67879)


Made with [Cursor](https://cursor.com)