### PR TITLE
docs: update Virt*Down runbooks for self-diagnosing alerts

### DIFF
--- a/docs/runbooks/VirtAPIDown.md
+++ b/docs/runbooks/VirtAPIDown.md
@@ -4,38 +4,65 @@
 
 No running `virt-api` pod has been detected for 10 minutes.
 
+The alert expression evaluates
+`cluster:kubevirt_virt_api_pods_running:count == 0` with a `for`
+duration of 10 minutes. The recording rule counts pods in
+`Running` phase matching `virt-api-.*`.
+
+In newer versions of KubeVirt, the alert expression is reworked to
+surface additional diagnostic labels (`pod`, `reason`) when a
+container waiting reason is available. If your alert includes these
+labels, see step 1 of the diagnosis below.
+
 ## Impact
 
 KubeVirt objects cannot send API calls.
 
 ## Diagnosis
 
-1. Set the `NAMESPACE` environment variable:
+1. **Check the alert labels**:
+
+   If the alert includes a `reason` label (for example,
+   `CrashLoopBackOff`, `ErrImagePull`, `ImagePullBackOff`), it
+   directly identifies why `virt-api` is down. The `pod` label
+   identifies the affected pod. Skip to [Mitigation](#mitigation)
+   for the matching root cause. If these labels are not present,
+   continue with the steps below.
+
+2. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(kubectl get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(kubectl get kubevirt -A \
+       -o custom-columns="":.metadata.namespace)"
    ```
 
-2. Check the status of the `virt-api` pods:
+3. Check the status of the `virt-api` pods:
 
    ```bash
    $ kubectl -n $NAMESPACE get pods -l kubevirt.io=virt-api
    ```
 
-3. Check the status of the `virt-api` deployment:
+4. Check the status of the `virt-api` deployment:
 
    ```bash
    $ kubectl -n $NAMESPACE get deploy virt-api -o yaml
    ```
 
-4. Check the `virt-api` deployment details for issues such as crashing pods or
-image pull failures:
+5. Check the `virt-api` deployment details for issues such as
+   crashing pods or image pull failures:
 
    ```bash
    $ kubectl -n $NAMESPACE describe deploy virt-api
    ```
 
-5. Check for issues such as nodes in a `NotReady` state:
+6. Review the logs of the `virt-api` pods:
+
+   ```bash
+   $ kubectl -n $NAMESPACE logs -l kubevirt.io=virt-api --previous
+   $ kubectl -n $NAMESPACE logs -l kubevirt.io=virt-api
+   ```
+
+7. Check for issues such as nodes in a `NotReady` state:
 
    ```bash
    $ kubectl get nodes
@@ -43,7 +70,21 @@ image pull failures:
 
 ## Mitigation
 
-Try to identify the root cause and resolve the issue.
+Try to identify the root cause and resolve the issue. Common
+causes include:
+
+- **CrashLoopBackOff**: The `virt-api` container is crashing
+  repeatedly. Check the pod logs for the root cause (panic, OOM,
+  misconfiguration).
+- **ErrImagePull / ImagePullBackOff**: The container image cannot
+  be pulled. Verify the image reference, registry availability,
+  and pull secrets.
+- **Pods absent**: No `virt-api` pods exist. Check whether the
+  deployment has been scaled to zero, deleted, or blocked by
+  resource constraints.
+- **Node issues**: Nodes may be in `NotReady` state or under
+  resource pressure.
+
 <!--DS: If you cannot resolve the issue, log in to the
 link:https://access.redhat.com[Customer Portal] and open a support case,
 attaching the artifacts gathered during the diagnosis procedure.-->

--- a/docs/runbooks/VirtControllerDown.md
+++ b/docs/runbooks/VirtControllerDown.md
@@ -1,45 +1,95 @@
 # VirtControllerDown
 
 ## Meaning
+
 No running `virt-controller` pod has been detected for 10 minutes.
 
+The alert expression evaluates
+`cluster:kubevirt_virt_controller_pods_running:count == 0` with a
+`for` duration of 10 minutes. The recording rule counts pods in
+`Running` phase matching `virt-controller-.*`.
+
+In newer versions of KubeVirt, the alert expression is reworked to
+surface additional diagnostic labels (`pod`, `reason`) when a
+container waiting reason is available. If your alert includes these
+labels, see step 1 of the diagnosis below.
+
 ## Impact
-Any actions related to virtual machine (VM) lifecycle management fail. This
-notably includes launching a new virtual machine instance (VMI) or shutting down
-an existing VMI.
+
+Any actions related to virtual machine (VM) lifecycle management
+fail. This notably includes launching a new virtual machine instance
+(VMI) or shutting down an existing VMI.
 
 ## Diagnosis
 
-1. Set the `NAMESPACE` environment variable:
+1. **Check the alert labels**:
+
+   If the alert includes a `reason` label (for example,
+   `CrashLoopBackOff`, `ErrImagePull`, `ImagePullBackOff`), it
+   directly identifies why `virt-controller` is down. The `pod`
+   label identifies the affected pod. Skip to
+   [Mitigation](#mitigation) for the matching root cause. If these
+   labels are not present, continue with the steps below.
+
+2. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(kubectl get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(kubectl get kubevirt -A \
+       -o custom-columns="":.metadata.namespace)"
    ```
 
-2. Check the status of the `virt-controller` deployment:
+3. Check the status of the `virt-controller` deployment:
 
    ```bash
-   $ kubectl get deployment -n $NAMESPACE virt-controller -o yaml
+   $ kubectl -n $NAMESPACE get deploy virt-controller -o yaml
    ```
 
-3. Review the logs of the `virt-controller` pod:
+4. Check the `virt-controller` deployment details for issues such
+   as crashing pods or image pull failures:
 
    ```bash
-   $ kubectl get logs <virt-controller>
+   $ kubectl -n $NAMESPACE describe deploy virt-controller
+   ```
+
+5. Check the status of the `virt-controller` pods:
+
+   ```bash
+   $ kubectl -n $NAMESPACE get pods \
+       -l kubevirt.io=virt-controller
+   ```
+
+6. Review the logs of the `virt-controller` pods:
+
+   ```bash
+   $ kubectl -n $NAMESPACE logs -l kubevirt.io=virt-controller \
+       --previous
+   $ kubectl -n $NAMESPACE logs -l kubevirt.io=virt-controller
+   ```
+
+7. Check for issues such as nodes in a `NotReady` state:
+
+   ```bash
+   $ kubectl get nodes
    ```
 
 ## Mitigation
 
-This alert can have a variety of causes, including the following:
+Try to identify the root cause and resolve the issue. Common
+causes include:
 
-- Node resource exhaustion
-- Not enough memory on the cluster
-- Nodes are down
-- The API server is overloaded. For example, the scheduler might be under a
-heavy load and therefore not completely available.
-- Networking issues
-
-Identify the root cause and fix it, if possible.
+- **CrashLoopBackOff**: The `virt-controller` container is
+  crashing repeatedly. Check the pod logs for the root cause
+  (panic, OOM, misconfiguration).
+- **ErrImagePull / ImagePullBackOff**: The container image cannot
+  be pulled. Verify the image reference, registry availability,
+  and pull secrets.
+- **Pods absent**: No `virt-controller` pods exist. Check whether
+  the deployment has been scaled to zero, deleted, or blocked by
+  resource constraints.
+- **Node resource exhaustion**: Not enough memory or CPU on the
+  cluster to schedule the pods.
+- **Node issues**: Nodes may be in `NotReady` state or under
+  resource pressure.
 
 <!--DS: If you cannot resolve the issue, log in to the
 link:https://access.redhat.com[Customer Portal] and open a support case,

--- a/docs/runbooks/VirtHandlerDown.md
+++ b/docs/runbooks/VirtHandlerDown.md
@@ -4,56 +4,94 @@
 
 No running `virt-handler` pod has been detected for 10 minutes.
 
-The `virt-handler` runs on every node that can schedule VMIs. It is
-responsible for domain lifecycle, network configuration, and other
-node-level operations for virtual machine instances.
+The alert expression evaluates
+`cluster:kubevirt_virt_handler_pods_running:count == 0` with a `for`
+duration of 10 minutes. The recording rule counts pods in `Running`
+phase matching `virt-handler-.*`. Because the recording rule
+aggregates across all pods, the alert carries only static labels
+(`severity`, `operator_health_impact`) and does not include
+per-pod or per-node dimensions.
+
+The `virt-handler` runs as a DaemonSet on every node that can
+schedule VMIs. It is responsible for domain lifecycle, network
+configuration, and other node-level operations for virtual machine
+instances.
+
+In newer versions of KubeVirt, the alert expression is reworked to
+surface additional diagnostic labels (`pod`, `node`, `reason`) when
+a container waiting reason is available. If your alert includes
+these labels, see step 1 of the diagnosis below.
 
 ## Impact
 
-Virtual machine instances (VMIs) on affected nodes cannot be managed properly.
-New VMIs may not start on nodes without a running `virt-handler`, and
-existing VMIs may not receive updates or clean shutdowns.
+Virtual machine instances (VMIs) on affected nodes cannot be managed
+properly. New VMIs may not start on nodes without a running
+`virt-handler`, and existing VMIs may not receive updates or clean
+shutdowns.
 
 ## Diagnosis
 
-1. Set the `NAMESPACE` environment variable:
+1. **Check the alert labels**:
+
+   If the alert includes a `reason` label (for example,
+   `CrashLoopBackOff`, `ErrImagePull`, `ImagePullBackOff`), it
+   directly identifies why `virt-handler` is down. The `pod` and
+   `node` labels identify the affected pod and node. Skip to
+   [Mitigation](#mitigation) for the matching root cause. If these
+   labels are not present, continue with the steps below.
+
+2. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(kubectl get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(kubectl get kubevirt -A \
+       -o custom-columns="":.metadata.namespace)"
    ```
 
-2. Check the status of the `virt-handler` DaemonSet and pods:
+3. Check the status of the `virt-handler` DaemonSet and pods:
 
    ```bash
    $ kubectl -n $NAMESPACE get daemonset virt-handler -o yaml
    $ kubectl -n $NAMESPACE get pods -l kubevirt.io=virt-handler
    ```
 
-3. Check DaemonSet events and pod status:
+4. Check DaemonSet events and pod status:
 
    ```bash
    $ kubectl -n $NAMESPACE describe daemonset virt-handler
    $ kubectl -n $NAMESPACE describe pod -l kubevirt.io=virt-handler
    ```
 
-4. Check for node issues (e.g. nodes not ready or taints):
+5. Check for node issues (for example, nodes not ready or taints):
 
    ```bash
    $ kubectl get nodes
    ```
 
-5. If any `virt-handler` pod exists, review its logs:
+6. If any `virt-handler` pod exists, review its logs:
 
    ```bash
-   $ kubectl -n $NAMESPACE logs <virt-handler-pod-name> --previous
-   $ kubectl -n $NAMESPACE logs <virt-handler-pod-name>
+   $ kubectl -n $NAMESPACE logs -l kubevirt.io=virt-handler \
+       --previous
+   $ kubectl -n $NAMESPACE logs -l kubevirt.io=virt-handler
    ```
 
 ## Mitigation
 
-Identify why `virt-handler` pods are down (e.g. DaemonSet not scheduling, pods
-crashing, node issues, image pull failures) and restore the DaemonSet so
-`virt-handler` runs on schedulable nodes.
+Try to identify the root cause and resolve the issue. Common
+causes include:
+
+- **CrashLoopBackOff**: The `virt-handler` container is crashing
+  repeatedly. Check the pod logs for the root cause (panic, OOM,
+  misconfiguration).
+- **ErrImagePull / ImagePullBackOff**: The container image cannot
+  be pulled. Verify the image reference, registry availability,
+  and pull secrets.
+- **Pods absent**: No `virt-handler` pods exist. Check whether the
+  DaemonSet has been deleted, is not scheduling due to node taints,
+  or is blocked by resource constraints.
+- **Node issues**: Nodes may be in `NotReady` state, under resource
+  pressure, or have taints that prevent the DaemonSet from
+  scheduling.
 
 <!--DS: If you cannot resolve the issue, log in to the
 link:https://access.redhat.com[Customer Portal] and open a support case,

--- a/docs/runbooks/VirtOperatorDown.md
+++ b/docs/runbooks/VirtOperatorDown.md
@@ -2,57 +2,83 @@
 
 ## Meaning
 
-This alert fires when no `virt-operator` pod in the `Running` state has been
-detected for 10 minutes.
+This alert fires when
+`cluster:kubevirt_virt_operator_pods_running:count == 0` for 10
+minutes, meaning no `virt-operator` pod in `Running` phase has been
+detected.
 
-The `virt-operator` is the first Operator to start in a cluster. Its primary
-responsibilities include the following:
+The `virt-operator` is the first Operator to start in a cluster. Its
+primary responsibilities include the following:
 
 - Installing, live-updating, and live-upgrading a cluster
-- Monitoring the life cycle of top-level controllers, such as `virt-controller`,
-`virt-handler`, `virt-launcher`, and managing their reconciliation
-- Certain cluster-wide tasks, such as certificate rotation and infrastructure
-management
+- Monitoring the life cycle of top-level controllers, such as
+  `virt-controller`, `virt-handler`, `virt-launcher`, and managing
+  their reconciliation
+- Certain cluster-wide tasks, such as certificate rotation and
+  infrastructure management
 
-The `virt-operator` deployment has a default replica of 2 pods.
+In newer versions of KubeVirt, the alert expression is reworked to
+surface additional diagnostic labels (`pod`, `reason`) when a
+container waiting reason is available. If your alert includes these
+labels, see step 1 of the diagnosis below.
 
 ## Impact
 
 This alert indicates a failure at the level of the cluster. Critical
-cluster-wide management functionalities, such as certification rotation,
-upgrade, and reconciliation of controllers, might not be available.
+cluster-wide management functionalities, such as certification
+rotation, upgrade, and reconciliation of controllers, might not be
+available.
 
-The `virt-operator` is not directly responsible for virtual machines (VMs) in
-the cluster. Therefore, its temporary unavailability does not significantly
-affect VM workloads.
+The `virt-operator` is not directly responsible for virtual machines
+(VMs) in the cluster. Therefore, its temporary unavailability does
+not significantly affect VM workloads.
 
 ## Diagnosis
 
-1. Set the `NAMESPACE` environment variable:
+1. **Check the alert labels**:
+
+   If the alert includes a `reason` label (for example,
+   `CrashLoopBackOff`, `ErrImagePull`, `ImagePullBackOff`), it
+   directly identifies why `virt-operator` is down. The `pod` label
+   identifies the affected pod. Skip to
+   [Mitigation](#mitigation) for the matching root cause. If these
+   labels are not present, continue with the steps below.
+
+2. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(kubectl get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(kubectl get kubevirt -A \
+       -o custom-columns="":.metadata.namespace)"
    ```
 
-2. Check the status of the `virt-operator` deployment:
+3. Check the status of the `virt-operator` deployment:
 
    ```bash
    $ kubectl -n $NAMESPACE get deploy virt-operator -o yaml
    ```
 
-3. Obtain the details of the `virt-operator` deployment:
+4. Obtain the details of the `virt-operator` deployment:
 
    ```bash
    $ kubectl -n $NAMESPACE describe deploy virt-operator
    ```
 
-4. Check the status of the `virt-operator` pods:
+5. Check the status of the `virt-operator` pods:
 
    ```bash
-   $ kubectl get pods -n $NAMESPACE -l=kubevirt.io=virt-operator
+   $ kubectl -n $NAMESPACE get pods \
+       -l kubevirt.io=virt-operator
    ```
 
-5. Check for node issues, such as a `NotReady` state:
+6. Review the logs of the `virt-operator` pods:
+
+   ```bash
+   $ kubectl -n $NAMESPACE logs -l kubevirt.io=virt-operator \
+       --previous
+   $ kubectl -n $NAMESPACE logs -l kubevirt.io=virt-operator
+   ```
+
+7. Check for node issues, such as a `NotReady` state:
 
    ```bash
    $ kubectl get nodes
@@ -60,8 +86,21 @@ affect VM workloads.
 
 ## Mitigation
 
-Based on the information obtained during the diagnosis procedure, try to
-identify the root cause and resolve the issue.
+Try to identify the root cause and resolve the issue. Common
+causes include:
+
+- **CrashLoopBackOff**: The `virt-operator` container is crashing
+  repeatedly. Check the pod logs for the root cause (panic, OOM,
+  misconfiguration).
+- **ErrImagePull / ImagePullBackOff**: The container image cannot
+  be pulled. Verify the image reference, registry availability,
+  and pull secrets.
+- **Pods absent**: No `virt-operator` pods exist. Check whether the
+  deployment has been scaled to zero, deleted, or blocked by
+  resource constraints.
+- **Node issues**: Nodes may be in `NotReady` state, under resource
+  pressure, or have scheduling constraints that prevent the pods
+  from running.
 
 <!--DS: If you cannot resolve the issue, log in to the
 link:https://access.redhat.com[Customer Portal] and open a support case,


### PR DESCRIPTION
## Summary

Update VirtAPIDown, VirtControllerDown, VirtHandlerDown, and
VirtOperatorDown runbooks to reflect the self-diagnosing alert
changes introduced in kubevirt/kubevirt#17985.

In the newer versions, these alerts include `pod` and `reason`
labels when a container waiting reason is available (e.g.
`CrashLoopBackOff`, `ErrImagePull`), allowing immediate diagnosis
from the alert itself.

## Changes per runbook

Each runbook now:
- **Meaning**: explains the new self-diagnosing behavior and notes
  that older KubeVirt versions fire without diagnostic labels
- **Diagnosis**: adds "Check the alert labels" as the first step,
  so users with vthe updated versions can skip manual commands when the alert
  already tells them the root cause; adds log-checking steps
  using label selectors
- **Mitigation**: structured per root cause (`CrashLoopBackOff`,
  `ErrImagePull`/`ImagePullBackOff`, pods absent, node issues)

## Backward compatibility

The runbooks are linked from older KubeVirt versions that do not
include the self-diagnosing labels. Each runbook explicitly notes
that diagnostic labels are available "In newer versions"
and that "older KubeVirt versions fire without diagnostic labels."
The manual diagnosis steps remain for users on older versions.

## Related PRs

- kubevirt/kubevirt#17985 - self-diagnosing Virt*Down alerts
- kubevirt/kubevirt#17995 - namespace label for all alerts

Signed-off-by: Shirly Radco <sradco@redhat.com>
Co-authored-by: Cursor <cursoragent@cursor.com>

Made with [Cursor](https://cursor.com)