### PR TITLE
Fix VMNonRecoverableOSPanic to reflect both >0 and >5 cases

### DIFF
--- a/docs/runbooks/VMNonRecoverableOSPanic.md
+++ b/docs/runbooks/VMNonRecoverableOSPanic.md
@@ -2,8 +2,8 @@
 
 ## Meaning
 
-This alert fires when a VM has experienced more than 5 non-recoverable guest
-OS panics in the last 24 hours. The alert is based on the
+This alert fires when a VM has experienced non-recoverable guest OS panics in
+the last 24 hours. The alert is based on the
 `kubevirt_vmi_guest_os_panic_total` metric, which tracks panic events for all
 panic types (pvpanic, hyper-v, s390, etc.).
 


### PR DESCRIPTION
Remove the specific `> 5 panics ` threshold from the runbook's Meaning section, making it applicable to both the KubeVirt (critical, > 5) and HCO (warning, > 0) variants of the VMNonRecoverableOSPanic alert.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
