### PR TITLE
Remove trailing punctuation before check for the closing backtick

### DIFF
--- a/tools/runbook-sync-downstream/pkg/transform/transform.go
+++ b/tools/runbook-sync-downstream/pkg/transform/transform.go
@@ -153,9 +153,19 @@ func replaceOnlyInText(text string, old string, new string) string {
 				}
 			}
 
+			// Trim trailing punctuation so a closing backtick immediately
+			// followed by e.g. "." or "," (as in "`virt-api-.*`.") is still
+			// detected as the end of an inline code span. Otherwise the state
+			// stays stuck open and the rest of the document is left untouched.
+			//
+			// This only applies to inline code: a fenced-code line ending in
+			// "```." is code content, not a valid closing delimiter, so block
+			// code must be closed only by a bare "```" (checked on trimmedWord).
+			inlineCloser := strings.TrimRight(trimmedWord, ".,;:!?)")
+
 			if inBlockCode && strings.HasSuffix(trimmedWord, "```") {
 				inBlockCode = false
-			} else if inInlineCode && strings.HasSuffix(trimmedWord, "`") {
+			} else if inInlineCode && strings.HasSuffix(inlineCloser, "`") {
 				inInlineCode = false
 			}
 

--- a/tools/runbook-sync-downstream/pkg/transform/transform_test.go
+++ b/tools/runbook-sync-downstream/pkg/transform/transform_test.go
@@ -1,0 +1,112 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+
+package transform
+
+import "testing"
+
+// replaceOnlyInText re-joins lines with a trailing "\n", so its output always
+// ends with a newline. The inputs below intentionally omit the trailing newline
+// to keep the expectations focused on the replacement behavior rather than that
+// artifact (which ReplaceContents later trims away).
+func TestReplaceOnlyInText(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "replaces term in plain text",
+			in:   "KubeVirt objects cannot send API calls.",
+			want: "OpenShift Virtualization objects cannot send API calls.\n",
+		},
+		{
+			name: "does not replace term in a title line",
+			in:   "# KubeVirt is great",
+			want: "# KubeVirt is great\n",
+		},
+		{
+			name: "does not replace term inside inline code",
+			in:   "Run the `KubeVirt` command.",
+			want: "Run the `KubeVirt` command.\n",
+		},
+		{
+			// Regression test: the punctuation-trimming rule must apply to
+			// inline code only. A fenced-code line ending in "```." is code
+			// content, not a valid closing delimiter, so block code stays open
+			// and "KubeVirt" inside it must be left untouched.
+			name: "keeps block code open when a fence line ends in punctuation",
+			in: "```bash\n" +
+				"KubeVirt```.\n" +
+				"KubeVirt\n" +
+				"```",
+			want: "```bash\n" +
+				"KubeVirt```.\n" +
+				"KubeVirt\n" +
+				"```\n",
+		},
+		{
+			// Regression test: a closing backtick followed by punctuation
+			// ("`virt-api-.*`.") used to leave the inline-code state stuck
+			// open, so no later term was ever replaced.
+			name: "replaces term after inline code whose closing backtick is followed by punctuation",
+			in: "The recording rule counts pods matching `virt-api-.*`.\n" +
+				"KubeVirt objects cannot send API calls.",
+			want: "The recording rule counts pods matching `virt-api-.*`.\n" +
+				"OpenShift Virtualization objects cannot send API calls.\n",
+		},
+		{
+			// End-to-end regression against the reported VirtAPIDown runbook:
+			// the "## Impact" line was left unconverted because of the stuck
+			// inline-code state introduced earlier by "`virt-api-.*`.".
+			name: "replaces term in the Impact section of a realistic runbook",
+			in: "# VirtAPIDown\n" +
+				"\n" +
+				"## Meaning\n" +
+				"\n" +
+				"No running `virt-api` pod has been detected for 10 minutes.\n" +
+				"\n" +
+				"The recording rule counts pods in `Running` phase matching `virt-api-.*`.\n" +
+				"\n" +
+				"## Impact\n" +
+				"\n" +
+				"KubeVirt objects cannot send API calls.",
+			want: "# VirtAPIDown\n" +
+				"\n" +
+				"## Meaning\n" +
+				"\n" +
+				"No running `virt-api` pod has been detected for 10 minutes.\n" +
+				"\n" +
+				"The recording rule counts pods in `Running` phase matching `virt-api-.*`.\n" +
+				"\n" +
+				"## Impact\n" +
+				"\n" +
+				"OpenShift Virtualization objects cannot send API calls.\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := replaceOnlyInText(tt.in, "KubeVirt", "OpenShift Virtualization")
+			if got != tt.want {
+				t.Errorf("replaceOnlyInText() mismatch\n in:   %q\n got:  %q\n want: %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

some instances of the sync are not replacing the product name
https://github.com/openshift/runbooks/pull/444/changes

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove trailing punctuation before check for the closing backtick
```
