### PR TITLE
ci: skip Perses sync PRs with no YAML changes

### DIFF
--- a/.github/workflows/perses-dashboards-sync.yaml
+++ b/.github/workflows/perses-dashboards-sync.yaml
@@ -33,10 +33,15 @@ jobs:
       - name: Check for changes
         id: changes
         run: |
-          if [ -n "$(git status --porcelain dashboards/perses/ go.mod go.sum)" ]; then
+          # Open a PR only when generated YAML changed. go.mod-only
+          # pin bumps are skipped; they are included when YAML changes.
+          if [ -n "$(git status --porcelain dashboards/perses/)" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
+            if [ -n "$(git status --porcelain go.mod go.sum)" ]; then
+              echo "Skipping PR: module pin changed but generated dashboards are unchanged."
+            fi
           fi
 
       - name: Create pull request


### PR DESCRIPTION
The daily sync runs go get @latest, which often
moves the MCOA pkg/perses pin even when generated
dashboard YAML is unchanged. Those PRs have
nothing to review or ship. Open a PR only when
dashboards/perses/ changes; include the pin bump
in that same PR when YAML actually changes.

Signed-off-by: Shirly Radco <sradco@redhat.com>
Co-authored-by: AI Assistant <noreply@cursor.com>

Made with [Cursor](https://cursor.com)