### PR TITLE
Update open runbook sync PRs in place instead of skipping

### DIFF
--- a/tools/runbook-sync-downstream/main.go
+++ b/tools/runbook-sync-downstream/main.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/google/go-github/v60/github"
 	"k8s.io/klog/v2"
@@ -140,37 +141,108 @@ func (rbSync *runbookSync) createRunbooksBranches(runbooksToUpdate []runbook, ru
 	}
 }
 
+// runbookPRSync captures everything the shared PR sync flow needs to decide
+// whether to skip, create, or update a downstream runbook PR.
+type runbookPRSync struct {
+	branchName string
+	filePath   string // path of the runbook file relative to the repo root
+	commitMsg  string
+	prTitle    string
+	prBody     string
+	generate   func() error                              // writes the runbook file to disk
+	afterSync  func(currentPR *github.PullRequest) error // optional, runs after a PR is created or updated in place, receiving the PR to keep open
+}
+
+// syncRunbookPR skips closed PRs, updates open PRs in place when the generated
+// content differs, and otherwise creates a fresh PR.
+func (rbSync *runbookSync) syncRunbookPR(p runbookPRSync) string {
+	prExists, pr, err := rbSync.prForBranchPreviouslyCreated(p.branchName)
+	if err != nil {
+		klog.Fatalf("failed to check if branch exists: %v", err)
+	}
+
+	if prExists && pr.GetState() == "closed" {
+		klog.Infof("PR for '%s' is closed, skipping: %s", p.branchName, pr.GetHTMLURL())
+		return p.branchName
+	}
+
+	worktree, err := newBranchFromMain(rbSync.downstreamRepo, p.branchName)
+	if err != nil {
+		klog.Fatalf("failed to create branch: %v", err)
+	}
+
+	if err := p.generate(); err != nil {
+		klog.Fatalf("failed to generate runbook: %v", err)
+	}
+
+	if err := rbSync.commit(worktree, p.commitMsg); err != nil {
+		klog.Fatalf("failed to commit changes: %v", err)
+	}
+
+	if prExists {
+		rbSync.updateOpenPR(p, pr)
+		if err := rbSync.runAfterSync(p, pr); err != nil {
+			klog.Fatalf("failed to run post-sync step: %v", err)
+		}
+		return p.branchName
+	}
+
+	if err := rbSync.push(p.branchName, false); err != nil {
+		klog.Fatalf("failed to push changes: %v", err)
+	}
+
+	newPR, err := rbSync.createPR(p.branchName, p.prTitle, p.prBody)
+	if err != nil {
+		klog.Fatalf("failed to create PR: %v", err)
+	}
+
+	if err := rbSync.runAfterSync(p, newPR); err != nil {
+		klog.Fatalf("failed to run post-sync step: %v", err)
+	}
+
+	return p.branchName
+}
+
+// runAfterSync runs the optional post-sync hook, closing other outdated PRs for
+// the same runbook on both the create and in-place update paths.
+func (rbSync *runbookSync) runAfterSync(p runbookPRSync, currentPR *github.PullRequest) error {
+	if p.afterSync == nil {
+		return nil
+	}
+	return p.afterSync(currentPR)
+}
+
+// updateOpenPR force-pushes the regenerated content to an already-open PR's
+// branch, but only when it differs from what is already there.
+func (rbSync *runbookSync) updateOpenPR(p runbookPRSync, pr *github.PullRequest) {
+	remoteContent, err := forkBranchFileContent(rbSync.downstreamRepo, p.branchName, p.filePath)
+	if err != nil {
+		klog.Fatalf("failed to read fork branch content: %v", err)
+	}
+
+	if remoteContent != nil {
+		matches, err := generatedFileMatches(downstreamCloneDir, p.filePath, remoteContent)
+		if err != nil {
+			klog.Fatalf("failed to compare runbook content: %v", err)
+		}
+		if matches {
+			klog.Infof("open PR '%s' is already up to date, skipping: %s", p.branchName, pr.GetHTMLURL())
+			return
+		}
+	}
+
+	klog.Infof("open PR '%s' is out of date, updating: %s", p.branchName, pr.GetHTMLURL())
+	if err := rbSync.push(p.branchName, true); err != nil {
+		klog.Fatalf("failed to force-push changes: %v", err)
+	}
+}
+
 func (rbSync *runbookSync) updateRunbook(rb runbook) string {
 	lastUpdateDate := rb.upstreamLastUpdated.Format("20060102150405")
 	runbookName := strings.Replace(rb.name, ".md", "", -1)
 	branchName := fmt.Sprintf("cnv-runbook-sync-%s/%s", lastUpdateDate, runbookName)
 
-	prExists, pr, err := rbSync.prForBranchPreviouslyCreated(branchName)
-	if err != nil {
-		klog.Fatalf("failed to check if branch exists: %v", err)
-	}
-
-	if prExists {
-		klog.Infof("PR for '%s' was previously created: %s", branchName, pr.GetHTMLURL())
-		return branchName
-	}
-
-	worktree, err := newBranchFromMain(rbSync.downstreamRepo, branchName)
-	if err != nil {
-		klog.Fatalf("failed to create branch: %v", err)
-	}
-
-	err = copyRunbook(rb.name)
-	if err != nil {
-		klog.Fatalf("failed to copy file: %v", err)
-	}
-
 	commitMessage := fmt.Sprintf("Sync CNV runbook %s (Updated at %s)", rb.name, rb.upstreamLastUpdated)
-
-	err = rbSync.commitAndPush(worktree, commitMessage)
-	if err != nil {
-		klog.Fatalf("failed to push changes: %v", err)
-	}
 
 	body := fmt.Sprintf(
 		"This is an automated PR by 'tools/openshift-virtualization-operator/runbook-sync'.\n\n"+
@@ -180,46 +252,24 @@ func (rbSync *runbookSync) updateRunbook(rb runbook) string {
 		rb.name, upstreamRepositoryURL, rb.upstreamLastUpdated, prReviewersFmt,
 	)
 
-	newPR, err := rbSync.createPR(branchName, commitMessage, body)
-	if err != nil {
-		klog.Fatalf("failed to create PR: %v", err)
-	}
-
-	if err := rbSync.closeOutdatedRunbookPRs(newPR, runbookName); err != nil {
-		klog.Fatalf("failed to close outdated PRs: %v", err)
-	}
-
-	return branchName
+	return rbSync.syncRunbookPR(runbookPRSync{
+		branchName: branchName,
+		filePath:   path.Join(downstreamRunbooksDir, rb.name),
+		commitMsg:  commitMessage,
+		prTitle:    commitMessage,
+		prBody:     body,
+		generate:   func() error { return copyRunbook(rb.name) },
+		afterSync: func(currentPR *github.PullRequest) error {
+			return rbSync.closeOutdatedRunbookPRs(currentPR, runbookName)
+		},
+	})
 }
 
 func (rbSync *runbookSync) deprecateRunbook(rb runbook) string {
 	runbookName := strings.Replace(rb.name, ".md", "", -1)
 	branchName := fmt.Sprintf("cnv-runbook-deprecate-%s", runbookName)
 
-	prExists, pr, err := rbSync.prForBranchPreviouslyCreated(branchName)
-	if err != nil {
-		klog.Fatalf("failed to check if branch exists: %v", err)
-	}
-
-	if prExists {
-		klog.Infof("PR for '%s' was previously created: %s", branchName, pr.GetHTMLURL())
-		return branchName
-	}
-
-	worktree, err := newBranchFromMain(rbSync.downstreamRepo, branchName)
-	if err != nil {
-		klog.Fatalf("failed to create branch: %v", err)
-	}
-
-	klog.Infof("updating runbook with deprecation message")
-	deprecatedRunbook(runbookName, downstreamCloneDir)
-
 	commitMessage := fmt.Sprintf("Deprecate CNV runbook %s", runbookName)
-
-	err = rbSync.commitAndPush(worktree, commitMessage)
-	if err != nil {
-		klog.Fatalf("failed to push changes: %v", err)
-	}
 
 	body := fmt.Sprintf(
 		"This is an automated PR by 'tools/openshift-virtualization-operator/runbook-sync'.\n\n"+
@@ -229,15 +279,21 @@ func (rbSync *runbookSync) deprecateRunbook(rb runbook) string {
 		rb.name, upstreamRepositoryURL, prReviewersFmt,
 	)
 
-	_, err = rbSync.createPR(branchName, commitMessage, body)
-	if err != nil {
-		klog.Fatalf("failed to create PR: %v", err)
-	}
-
-	return branchName
+	return rbSync.syncRunbookPR(runbookPRSync{
+		branchName: branchName,
+		filePath:   path.Join(downstreamRunbooksDir, rb.name),
+		commitMsg:  commitMessage,
+		prTitle:    commitMessage,
+		prBody:     body,
+		generate: func() error {
+			klog.Infof("updating runbook with deprecation message")
+			deprecatedRunbook(runbookName, downstreamCloneDir)
+			return nil
+		},
+	})
 }
 
-func (rbSync *runbookSync) commitAndPush(worktree *git.Worktree, msg string) error {
+func (rbSync *runbookSync) commit(worktree *git.Worktree, msg string) error {
 	_, err := worktree.Add(downstreamRunbooksDir)
 	if err != nil {
 		return fmt.Errorf("failed to add changes: %w", err)
@@ -255,14 +311,32 @@ func (rbSync *runbookSync) commitAndPush(worktree *git.Worktree, msg string) err
 	}
 	klog.Infof("successfully committed: %s", msg)
 
+	return nil
+}
+
+// push publishes branchName to the fork remote. When force is true it overwrites
+// the remote branch, which is required to update an already-open PR whose branch
+// has diverged from the freshly recreated local branch.
+func (rbSync *runbookSync) push(branchName string, force bool) error {
 	if rbSync.dryRun {
-		klog.Warning("[DRY RUN] skipping push")
+		if force {
+			klog.Warningf("[DRY RUN] would force-push to update branch %s", branchName)
+		} else {
+			klog.Warning("[DRY RUN] skipping push")
+		}
 		return nil
 	}
 
-	err = rbSync.downstreamRepo.Push(&git.PushOptions{
+	pushOpts := &git.PushOptions{
 		RemoteName: forkRemoteName,
-	})
+	}
+	if force {
+		refSpec := config.RefSpec(fmt.Sprintf("+refs/heads/%s:refs/heads/%s", branchName, branchName))
+		pushOpts.RefSpecs = []config.RefSpec{refSpec}
+		pushOpts.Force = true
+	}
+
+	err := rbSync.downstreamRepo.Push(pushOpts)
 	if err != nil {
 		return fmt.Errorf("failed to push changes: %w", err)
 	}
@@ -282,6 +356,14 @@ func (rbSync *runbookSync) prForBranchPreviouslyCreated(branchName string) (bool
 
 	if len(prs) == 0 {
 		return false, nil, nil
+	}
+
+	// Prefer an open PR when both open and closed PRs exist for the branch, so an
+	// open PR is updated in place rather than being treated as closed.
+	for _, pr := range prs {
+		if pr.GetState() == "open" {
+			return true, pr, nil
+		}
 	}
 
 	return true, prs[0], nil
@@ -313,7 +395,7 @@ func (rbSync *runbookSync) createPR(branchName string, title string, body string
 	return pr, nil
 }
 
-func (rbSync *runbookSync) closeOutdatedRunbookPRs(newPR *github.PullRequest, runbookName string) error {
+func (rbSync *runbookSync) closeOutdatedRunbookPRs(keepPR *github.PullRequest, runbookName string) error {
 	prs, _, err := rbSync.ghClient.PullRequests.List(context.Background(), downstreamRepositoryOwner, downstreamRepositoryName, &github.PullRequestListOptions{
 		State: "open",
 		Base:  downstreamMainBranch,
@@ -323,8 +405,8 @@ func (rbSync *runbookSync) closeOutdatedRunbookPRs(newPR *github.PullRequest, ru
 	}
 
 	for _, oldPR := range prs {
-		if isAutomatedPRForSameRunbook(oldPR, runbookName) && oldPR.GetNumber() != newPR.GetNumber() {
-			if err := rbSync.closeOutdatedRunbookPR(oldPR, newPR); err != nil {
+		if isAutomatedPRForSameRunbook(oldPR, runbookName) && oldPR.GetNumber() != keepPR.GetNumber() {
+			if err := rbSync.closeOutdatedRunbookPR(oldPR, keepPR); err != nil {
 				return err
 			}
 		}
@@ -337,7 +419,7 @@ func isAutomatedPRForSameRunbook(oldPR *github.PullRequest, runbookName string) 
 	return strings.Contains(oldPR.GetTitle(), runbookName) && oldPR.GetUser().GetLogin() == githubUsername
 }
 
-func (rbSync *runbookSync) closeOutdatedRunbookPR(oldPR *github.PullRequest, newPr *github.PullRequest) error {
+func (rbSync *runbookSync) closeOutdatedRunbookPR(oldPR *github.PullRequest, keepPR *github.PullRequest) error {
 	klog.Infof("closing outdated PR: %s", oldPR.GetHTMLURL())
 
 	if rbSync.dryRun {
@@ -345,7 +427,7 @@ func (rbSync *runbookSync) closeOutdatedRunbookPR(oldPR *github.PullRequest, new
 		return nil
 	}
 
-	body := *oldPR.Body + fmt.Sprintf("\n\nThis pull request has been closed in favor of a newer one. Please refer to the updated PR for the latest changes and discussion: %s.", newPr.GetHTMLURL())
+	body := *oldPR.Body + fmt.Sprintf("\n\nThis pull request has been closed in favor of another one. Please refer to the updated PR for the latest changes and discussion: %s.", keepPR.GetHTMLURL())
 	_, _, err := rbSync.ghClient.PullRequests.Edit(context.Background(), downstreamRepositoryOwner, downstreamRepositoryName, oldPR.GetNumber(), &github.PullRequest{
 		State: github.String("closed"),
 		Body:  github.String(body),

--- a/tools/runbook-sync-downstream/main.go
+++ b/tools/runbook-sync-downstream/main.go
@@ -22,6 +22,7 @@ package main
 import (
 	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -175,8 +176,14 @@ func (rbSync *runbookSync) syncRunbookPR(p runbookPRSync) string {
 		klog.Fatalf("failed to generate runbook: %v", err)
 	}
 
-	if err := rbSync.commit(worktree, p.commitMsg); err != nil {
+	action, err := classifyCommitResult(rbSync.commit(worktree, p.commitMsg), prExists)
+	if err != nil {
 		klog.Fatalf("failed to commit changes: %v", err)
+	}
+
+	if action == commitActionSkipNewPR {
+		klog.Infof("no changes to sync for '%s', skipping new PR", p.branchName)
+		return p.branchName
 	}
 
 	if prExists {
@@ -291,6 +298,35 @@ func (rbSync *runbookSync) deprecateRunbook(rb runbook) string {
 			return nil
 		},
 	})
+}
+
+// commitAction describes how syncRunbookPR should proceed after committing.
+type commitAction int
+
+const (
+	commitActionProceed      commitAction = iota // a commit was created; continue the sync
+	commitActionSkipNewPR                        // nothing to commit and no PR exists; skip creating an empty PR
+	commitActionKeepExisting                     // nothing to commit but a PR exists; continue to update it in place
+)
+
+// classifyCommitResult decides how to proceed based on the commit result. A
+// clean worktree (git.ErrEmptyCommit) means the generated content already
+// matches the base branch: skip creating a brand-new empty PR, but still
+// continue so an existing PR is updated in place. Any other commit error is
+// returned to the caller for fatal handling.
+func classifyCommitResult(err error, prExists bool) (commitAction, error) {
+	if err == nil {
+		return commitActionProceed, nil
+	}
+
+	if errors.Is(err, git.ErrEmptyCommit) {
+		if prExists {
+			return commitActionKeepExisting, nil
+		}
+		return commitActionSkipNewPR, nil
+	}
+
+	return commitActionProceed, err
 }
 
 func (rbSync *runbookSync) commit(worktree *git.Worktree, msg string) error {

--- a/tools/runbook-sync-downstream/runbook.go
+++ b/tools/runbook-sync-downstream/runbook.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path"
@@ -130,6 +131,18 @@ func copyRunbook(name string) error {
 
 	content := transform.ReplaceContents(string(file))
 	return createAndWriteFile(to, content)
+}
+
+// generatedFileMatches reports whether the freshly generated runbook file at
+// repoDir/filePath is byte-identical to want (the content already on the PR
+// branch). It returns an error if the generated file cannot be read.
+func generatedFileMatches(repoDir, filePath string, want []byte) (bool, error) {
+	got, err := os.ReadFile(path.Join(repoDir, filePath))
+	if err != nil {
+		return false, fmt.Errorf("failed to read generated file %s: %w", filePath, err)
+	}
+
+	return bytes.Equal(got, want), nil
 }
 
 func createAndWriteFile(path, content string) error {

--- a/tools/runbook-sync-downstream/runbook_test.go
+++ b/tools/runbook-sync-downstream/runbook_test.go
@@ -42,6 +42,51 @@ var _ = Describe("Runbook", func() {
 		})
 	})
 
+	Context("Generated file comparison", func() {
+		var tempDir string
+
+		BeforeEach(func() {
+			var err error
+			tempDir, err = os.MkdirTemp("", "runbook-diff-*")
+			Expect(err).ToNot(HaveOccurred())
+
+			runbooksDir := filepath.Join(tempDir, downstreamRunbooksDir)
+			err = os.MkdirAll(runbooksDir, 0755)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			err := os.RemoveAll(tempDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		relPath := filepath.Join(downstreamRunbooksDir, "Foo.md")
+
+		It("reports a match when the generated file is byte-identical", func() {
+			content := []byte("# Foo\n\nidentical content\n")
+			err := os.WriteFile(filepath.Join(tempDir, relPath), content, 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			matches, err := generatedFileMatches(tempDir, relPath, content)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(matches).To(BeTrue())
+		})
+
+		It("reports a mismatch when the generated file differs", func() {
+			err := os.WriteFile(filepath.Join(tempDir, relPath), []byte("# Foo\n\nfixed content\n"), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			matches, err := generatedFileMatches(tempDir, relPath, []byte("# Foo\n\nbuggy content\n"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(matches).To(BeFalse())
+		})
+
+		It("returns an error when the generated file is missing", func() {
+			_, err := generatedFileMatches(tempDir, relPath, []byte("anything"))
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	Context("Runbook deprecation", func() {
 		var tempDir string
 		var testRunbookPath string

--- a/tools/runbook-sync-downstream/runbook_test.go
+++ b/tools/runbook-sync-downstream/runbook_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/go-git/go-git/v5"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -84,6 +86,71 @@ var _ = Describe("Runbook", func() {
 		It("returns an error when the generated file is missing", func() {
 			_, err := generatedFileMatches(tempDir, relPath, []byte("anything"))
 			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("Empty commit handling", func() {
+		var tempDir string
+		var repo *git.Repository
+		var worktree *git.Worktree
+
+		BeforeEach(func() {
+			var err error
+			tempDir, err = os.MkdirTemp("", "runbook-commit-*")
+			Expect(err).ToNot(HaveOccurred())
+
+			repo, err = git.PlainInit(tempDir, false)
+			Expect(err).ToNot(HaveOccurred())
+
+			worktree, err = repo.Worktree()
+			Expect(err).ToNot(HaveOccurred())
+
+			// An empty runbooks dir means commit() stages nothing, which is the
+			// clean-worktree case that yields git.ErrEmptyCommit.
+			runbooksDir := filepath.Join(tempDir, downstreamRunbooksDir)
+			Expect(os.MkdirAll(runbooksDir, 0755)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			err := os.RemoveAll(tempDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns git.ErrEmptyCommit when the worktree is clean", func() {
+			rbSync := &runbookSync{downstreamRepo: repo}
+			err := rbSync.commit(worktree, "no changes")
+			Expect(errors.Is(err, git.ErrEmptyCommit)).To(BeTrue())
+		})
+
+		It("skips creating a new PR branch when a clean worktree has no PR", func() {
+			rbSync := &runbookSync{downstreamRepo: repo}
+			err := rbSync.commit(worktree, "no changes")
+
+			action, classifyErr := classifyCommitResult(err, false)
+			Expect(classifyErr).ToNot(HaveOccurred())
+			Expect(action).To(Equal(commitActionSkipNewPR))
+		})
+
+		It("continues to update an existing PR when a clean worktree has an open PR", func() {
+			rbSync := &runbookSync{downstreamRepo: repo}
+			err := rbSync.commit(worktree, "no changes")
+
+			action, classifyErr := classifyCommitResult(err, true)
+			Expect(classifyErr).ToNot(HaveOccurred())
+			Expect(action).To(Equal(commitActionKeepExisting))
+		})
+
+		It("proceeds normally when a commit was created", func() {
+			action, classifyErr := classifyCommitResult(nil, false)
+			Expect(classifyErr).ToNot(HaveOccurred())
+			Expect(action).To(Equal(commitActionProceed))
+		})
+
+		It("returns other commit errors for fatal handling", func() {
+			sentinel := errors.New("disk full")
+			action, classifyErr := classifyCommitResult(sentinel, true)
+			Expect(classifyErr).To(MatchError(sentinel))
+			Expect(action).To(Equal(commitActionProceed))
 		})
 	})
 

--- a/tools/runbook-sync-downstream/worktree.go
+++ b/tools/runbook-sync-downstream/worktree.go
@@ -20,9 +20,11 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 )
@@ -49,6 +51,50 @@ func getDirCurrentTree(repo *git.Repository, dir string) (*object.Tree, error) {
 	}
 
 	return runbooksTree, nil
+}
+
+// forkBranchFileContent fetches branchName from the fork remote and returns the
+// content of filePath as it currently exists on that branch. It returns
+// (nil, nil) when the branch or file is absent on the fork, so callers can treat
+// a missing remote file as "changed".
+func forkBranchFileContent(repo *git.Repository, branchName, filePath string) ([]byte, error) {
+	refSpec := config.RefSpec(fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", branchName, forkRemoteName, branchName))
+
+	err := repo.Fetch(&git.FetchOptions{
+		RemoteName: forkRemoteName,
+		RefSpecs:   []config.RefSpec{refSpec},
+	})
+	if err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
+		if errors.Is(err, git.NoMatchingRefSpecError{}) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to fetch fork branch %s: %w", branchName, err)
+	}
+
+	ref, err := repo.Reference(plumbing.NewRemoteReferenceName(forkRemoteName, branchName), true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve fork branch %s: %w", branchName, err)
+	}
+
+	commit, err := repo.CommitObject(ref.Hash())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get commit for fork branch %s: %w", branchName, err)
+	}
+
+	f, err := commit.File(filePath)
+	if err != nil {
+		if errors.Is(err, object.ErrFileNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read %s from fork branch %s: %w", filePath, branchName, err)
+	}
+
+	content, err := f.Contents()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read contents of %s from fork branch %s: %w", filePath, branchName, err)
+	}
+
+	return []byte(content), nil
 }
 
 func newBranchFromMain(repo *git.Repository, name string) (*git.Worktree, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update open runbook sync PRs in place instead of skipping
```
