### PR TITLE
Add HCO v1 API version documentation to the runbooks

### DIFF
--- a/docs/runbooks/CDIDataImportCronOutdated.md
+++ b/docs/runbooks/CDIDataImportCronOutdated.md
@@ -95,18 +95,27 @@ with the previous default storage class. The CDI will recreate the data volumes
 with the newly configured default storage class.
 
 3. If your cluster is installed in a restricted network environment, disable the
-`enableCommonBootImageImport` feature gate in order to opt out of automatic
-updates:
+common boot image import feature in order to opt out of automatic updates, by
+setting the `enableCommonBootImageImport` field to `false`:
 
-   ```bash
-   $ kubectl patch hco kubevirt-hyperconverged -n $CDI_NAMESPACE --type json -p '[{"op": "replace", "path": "/spec/featureGates/enableCommonBootImageImport", "value": false}]'
-   ```
+   * In version <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0--> or above, use the `v1` API
+     version:
+     ```bash
+     $ kubectl patch hco kubevirt-hyperconverged -n $CDI_NAMESPACE --type merge -p \
+     '{"spec": {"workloadSources": {"enableCommonBootImageImport": false}}}'
+     ```
+   * In versions earlier than <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->, use the
+     `v1beta1` API version:
+     ```bash
+     $ kubectl patch hco kubevirt-hyperconverged -n $CDI_NAMESPACE --type merge -p \
+     '{"spec": {"enableCommonBootImageImport": false}}'
+     ```
 
 <!--DS: If you cannot resolve the issue, log in to the
 link:https://access.redhat.com[Customer Portal] and open a support case,
 attaching the artifacts gathered during the diagnosis procedure.-->
 <!--USstart-->
-See the [HCO cluster configuration documentation](https://github.com/kubevirt/hyperconverged-cluster-operator/blob/main/docs/cluster-configuration.md#enablecommonbootimageimport-feature-gate)
+See the [v1 API HCO cluster configuration documentation](https://github.com/kubevirt/hyperconverged-cluster-operator/blob/main/docs/cluster-configuration.md#disabling-all-pre-defined-golden-images)
 for more information.
 
 If you cannot resolve the issue, see the following resources:

--- a/docs/runbooks/HCOGoldenImageWithNoArchitectureAnnotation.md
+++ b/docs/runbooks/HCOGoldenImageWithNoArchitectureAnnotation.md
@@ -16,8 +16,12 @@ For each DICT, if the `ssp.kubevirt.io/dict.architectures` annotation is
 missing, HCO triggers the `HCOGoldenImageWithNoArchitectureAnnotation`
 alert for this specific DICT.
 
-> **Note:** This alert only triggers if the `enableMultiArchBootImageImport`
-> feature gate is enabled in the `HyperConverged` CR.
+> **Note:** This alert only triggers if
+> * For version <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0--> or newer, the
+`spec.workloadSources.enableMultiArchBootImageImport` field in the `HyperConverged`
+CR, is `true`.
+> * For versions before <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->, the
+`enableMultiArchBootImageImport` feature gate is enabled in the `HyperConverged` CR.
 
 ## Impact
 
@@ -32,40 +36,60 @@ architecture than the image architecture, the VM fails to start.
 
 ```bash
   # Get the namespace of the HyperConverged CR
-  $ NAMESPACE="$(oc get hyperconverged -A --no-headers | awk '{print $1}')"
+  $ NAMESPACE="$(kubectl get hyperconverged -A --no-headers | awk '{print $1}')"
 
   # Read the HyperConverged CR
-  $ oc get hyperconverged -n "${NAMESPACE}" -o yaml
+  $ kubectl get hyperconverged -n "${NAMESPACE}" -o yaml
 ```
 
 2. If this command lists any DICT objects under the
-`spec.dataImportCronTemplates` field in the `HyperConverged` CR, check whether
+`dataImportCronTemplates` field in the `HyperConverged` CR, check whether
 the `ssp.kubevirt.io/dict.architectures` annotation is set for each of them. If
 the annotation is not set, then this alert is triggered.
 
    Below is an example for a HyperConverged CR with a valid DICT with the
-  `ssp.kubevirt.io/dict.architectures` annotation set:
-  ```yaml
-  apiVersion: hco.kubevirt.io/v1beta1
-  kind: HyperConverged
-  ...
-  spec:
-  ...
-    dataImportCronTemplates:
-      - metadata:
-          annotations:
-            ...
-            ssp.kubevirt.io/dict.architectures: amd64
-          name: the-name-of-the-dict
-        spec:
-          ...
-```
+  `ssp.kubevirt.io/dict.architectures` annotation set.
+
+   For version <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->, or newer, use the `v1` api version:
+   ```yaml
+   apiVersion: hco.kubevirt.io/v1
+   kind: HyperConverged
+   ...
+   spec:
+   ...
+     workloadSources:
+       dataImportCronTemplates:
+         - metadata:
+             annotations:
+               ...
+               ssp.kubevirt.io/dict.architectures: amd64
+             name: the-name-of-the-dict
+           spec:
+             ...
+   ```
+   For versions before <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->, use the
+   `v1beta1` api version:
+   ```yaml
+   apiVersion: hco.kubevirt.io/v1beta1
+   kind: HyperConverged
+   ...
+   spec:
+   ...
+     dataImportCronTemplates:
+       - metadata:
+           annotations:
+             ...
+             ssp.kubevirt.io/dict.architectures: amd64
+           name: the-name-of-the-dict
+         spec:
+           ...
+   ```
 
 The `status.nodeInfo.workloadsArchitectures` field in the `HyperConverged` CR
 shows the list of architectures that are supported by the cluster.
 
 User-defined DICTs are defined in the `HyperConverged` CR, in the
-`spec.dataImportCronTemplates` field.
+`dataImportCronTemplates` field.
 
 ## Mitigation
 
@@ -77,7 +101,7 @@ User-defined DICTs are defined in the `HyperConverged` CR, in the
 
    For details, see the
   [podman manifest inspect documentation](https://docs.podman.io/en/latest/markdown/podman-manifest-inspect.1.html).
-  
+
     If the image is a multi-architecture manifest ("fat manifest"), it includes the
 `manifests` field, which is a list of architectures supported by the image. If
 the image is not a multi-architecture manifest, you need to find out what

--- a/docs/runbooks/HCOGoldenImageWithNoSupportedArchitecture.md
+++ b/docs/runbooks/HCOGoldenImageWithNoSupportedArchitecture.md
@@ -17,9 +17,12 @@ supported by the cluster (which means that there is no node in the cluster with
 the architectures listed in the DICT annotation), HCO triggers the
 `HCOGoldenImageWithNoSupportedArchitecture` alert for this specific DICT.
 
-> **Note:** This only triggers if the `enableMultiArchBootImageImport`
-> feature gate is enabled in the `HyperConverged` CR.
-
+> **Note:** This alert only triggers if
+> * For version <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0--> or newer, the
+   `spec.workloadSources.enableMultiArchBootImageImport` field in the `HyperConverged`
+   CR, is `true`.
+> * For versions before <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->, the
+    `enableMultiArchBootImageImport` feature gate is enabled in the `HyperConverged` CR.
 ## Impact
 
 This alert triggers when the DICT is not supported by any of the nodes in the
@@ -32,10 +35,10 @@ is not available for use in the cluster.
 
 ```bash
   # Get the namespace of the HyperConverged CR
-  $ NAMESPACE="$(oc get hyperconverged -A --no-headers | awk '{print $1}')"
+  $ NAMESPACE="$(kubectl get hyperconverged -A --no-headers | awk '{print $1}')"
 
   # Read the HyperConverged CR
-  $ oc get hyperconverged -n "${NAMESPACE}" -o yaml
+  $ kubectl get hyperconverged -n "${NAMESPACE}" -o yaml
 ```
 
 2. Examine the following fields in the `HyperConverged` CR status:
@@ -67,7 +70,7 @@ architectures supported by the image, which was set in the
 ### Example
 
 ```yaml
-apiVersion: hco.kubevirt.io/v1beta1
+apiVersion: hco.kubevirt.io/v1
 kind: HyperConverged
 ...
 status:
@@ -96,9 +99,14 @@ DICTs or user-defined DICTs.
 
 ### Pre-defined DataImportCronTemplates
 
-Pre-defined DICTs are not defined in the `spec.dataImportCronTemplates`
+Pre-defined DICTs are not defined in the `dataImportCronTemplates`
 field in the `HyperConverged` CR. Instead, they are defined internally in the
 HCO application.
+
+> Please notice:
+> * In the `v1` API version, used in version <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->
+ or above, the `dataImportCronTemplates` field is under the `spec.workloadSources` field.
+> * In the `v1beta1` version, used in versions earlier than <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->, the `dataImportCronTemplates` field is under the `spec` field.
 
 All pre-defined DICTs are annotated with the `ssp.kubevirt.io/dict.architectures`
 annotation, and all of them support the `amd64`, `arm64`, and `s390x`
@@ -117,12 +125,28 @@ off:
   `status.dataImportCronTemplates` field of the `HyperConverged` CR, as
   described [in the Diagnosis section](#diagnosis).
 
-  2. Add the DICT to the `spec.dataImportCronTemplates` field in the
+  2. Add the DICT to the `dataImportCronTemplates` field in the
   `HyperConverged` CR. Add the `dataimportcrontemplate.kubevirt.io/enable`
   annotation with the value `false` to the DICT. Only the DICT name and the
   annotation are required.
 
        For example, to disable the `centos-stream10-image-cron` DICT:
+       * In version <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->
+         or above:
+       ```yaml
+       apiVersion: hco.kubevirt.io/v1
+       kind: HyperConverged
+       metadata:
+         name: kubevirt-hyperconverged
+       spec:
+         workloadSources:
+           dataImportCronTemplates:
+           - metadata:
+               name: centos-stream10-image-cron
+               annotations:
+                 dataimportcrontemplate.kubevirt.io/enable: 'false'
+        ```
+       * In versions earlier than <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->:
        ```yaml
        apiVersion: hco.kubevirt.io/v1beta1
        kind: HyperConverged
@@ -138,50 +162,86 @@ off:
 
      If you have a self-built image that is supported by the nodes in the cluster,
 you can modify the pre-defined DICT to use your image. To do so, add the DICT to
-the `spec.dataImportCronTemplates` field in the `HyperConverged` CR and modify
+the `dataImportCronTemplates` field in the `HyperConverged` CR and modify
 its `spec.source.registry` field.
 
   > Tip: you can find the pre-defined DICTs in the
   > `status.dataImportCronTemplates` field of the `HyperConverged` CR, as
-  > described [in the Diagnosis section](#diagnosis). Afterwards, you can copy
-  > the DICT from the field, and modify it in the `spec.dataImportCronTemplates`
+  > described [in the Diagnosis section](#diagnosis). Afterward, you can copy
+  > the DICT from the field, and modify it in the `dataImportCronTemplates`
   > field.
 
 3. Set the `ssp.kubevirt.io/dict.architectures` annotation to include all the
 architectures supported by your image.
 
    For example:
-  ```yaml
-  apiVersion: hco.kubevirt.io/v1beta1
-  kind: HyperConverged
-  metadata:
-    name: kubevirt-hyperconverged
-  spec:
-    dataImportCronTemplates:
-    - metadata:
-      annotations:
-        cdi.kubevirt.io/storage.bind.immediate.requested: "true"
-        ssp.kubevirt.io/dict.architectures: arch1,arch2
-      name: centos-stream10-image-cron
-    spec:
-      garbageCollect: Outdated
-      managedDataSource: centos-stream10
-      schedule: "0 */12 * * *"
-      template:
-        spec:
-          source:
-            registry:
-              url: docker://your-registry/your-image:latest
-          storage:
-            resources:
-              requests:
-                storage: 10Gi
-  ```
+   * In version <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->
+     or above, use the `v1` API version:
+       ```yaml
+       apiVersion: hco.kubevirt.io/v1
+       kind: HyperConverged
+       metadata:
+         name: kubevirt-hyperconverged
+       spec:
+         workloadSources:
+           dataImportCronTemplates:
+           - metadata:
+               annotations:
+                 cdi.kubevirt.io/storage.bind.immediate.requested: "true"
+                 ssp.kubevirt.io/dict.architectures: arch1,arch2
+               name: centos-stream10-image-cron
+             spec:
+               garbageCollect: Outdated
+               managedDataSource: centos-stream10
+               schedule: "0 */12 * * *"
+               template:
+                 spec:
+                   source:
+                     registry:
+                       url: docker://your-registry/your-image:latest
+                   storage:
+                     resources:
+                       requests:
+                         storage: 10Gi
+       ```
+   * In versions earlier than <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->,
+     use the `v1beta1` API version:
+       ```yaml
+       apiVersion: hco.kubevirt.io/v1beta1
+       kind: HyperConverged
+       metadata:
+         name: kubevirt-hyperconverged
+       spec:
+         dataImportCronTemplates:
+         - metadata:
+             annotations:
+               cdi.kubevirt.io/storage.bind.immediate.requested: "true"
+               ssp.kubevirt.io/dict.architectures: arch1,arch2
+             name: centos-stream10-image-cron
+           spec:
+             garbageCollect: Outdated
+             managedDataSource: centos-stream10
+             schedule: "0 */12 * * *"
+             template:
+               spec:
+                 source:
+                   registry:
+                     url: docker://your-registry/your-image:latest
+                 storage:
+                   resources:
+                     requests:
+                       storage: 10Gi
+       ```
 
 ### User-defined DataImportCronTemplates
 
-User-defined DICTs are defined in the `spec.dataImportCronTemplates` field of
-the of the HyperConverged CR.
+User-defined DICTs are defined in the `dataImportCronTemplates` field of
+the HyperConverged CR.
+
+> Please notice:
+> * In the `v1` API version, used in version <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->
+    or above, the `dataImportCronTemplates` field is under the `spec.workloadSources` field.
+> * In the `v1beta1` version, used in versions earlier than <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->, the `dataImportCronTemplates` field is under the `spec` field.
 
 1. Check what architectures are supported by the image:
 
@@ -208,22 +268,40 @@ cluster, or remove the DICT from the `HyperConverged` CR.
     It is also possible to disable the DICT, by adding the
     `dataimportcrontemplate.kubevirt.io/enable` annotation, with the value of
     `false`. For example:
-
-  ```yaml
-  apiVersion: hco.kubevirt.io/v1beta1
-  kind: HyperConverged
-  metadata:
-    name: kubevirt-hyperconverged
-  spec:
-    dataImportCronTemplates:
-    - metadata:
-      annotations:
-        dataimportcrontemplate.kubevirt.io/enable: "false"
-        ssp.kubevirt.io/dict.architectures: unsupported-arch1,unsupported-arch2
-      name: my-image
-    spec:
-      ...
-  ```
+    * In version <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->
+      or above:
+      ```yaml
+      apiVersion: hco.kubevirt.io/v1
+      kind: HyperConverged
+      metadata:
+        name: kubevirt-hyperconverged
+      spec:
+        workloadSources:
+          dataImportCronTemplates:
+          - metadata:
+              annotations:
+                dataimportcrontemplate.kubevirt.io/enable: "false"
+                ssp.kubevirt.io/dict.architectures: unsupported-arch1,unsupported-arch2
+              name: my-image
+            spec:
+              ...
+      ```
+    * In versions earlier than <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->:
+      ```yaml
+      apiVersion: hco.kubevirt.io/v1beta1
+      kind: HyperConverged
+      metadata:
+        name: kubevirt-hyperconverged
+      spec:
+        dataImportCronTemplates:
+        - metadata:
+            annotations:
+              dataimportcrontemplate.kubevirt.io/enable: "false"
+              ssp.kubevirt.io/dict.architectures: unsupported-arch1,unsupported-arch2
+            name: my-image
+          spec:
+            ...
+      ```
 
 For more information about building multi-architecture images, see the
 [podman documentation](https://docs.podman.io/en/latest/markdown/podman-manifest-create.1.html).

--- a/docs/runbooks/HCOInstallationIncomplete.md
+++ b/docs/runbooks/HCOInstallationIncomplete.md
@@ -19,16 +19,31 @@ the HCO:
 - Complete the installation by creating a `HyperConverged` CR with its
 default values:
 
-  ```bash
-  $ cat <<EOF | kubectl apply -f -
-  apiVersion: hco.kubevirt.io/v1beta1
-  kind: HyperConverged
-  metadata:
-    name: kubevirt-hyperconverged
-    namespace: kubevirt-hyperconverged
-  spec: {}
-  EOF
-  ```
+  * In version <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->
+    or above, use the `v1` API version:
+    ```bash
+    $ cat <<EOF | kubectl apply -f -
+    apiVersion: hco.kubevirt.io/v1
+    kind: HyperConverged
+    metadata:
+      name: kubevirt-hyperconverged
+      namespace: kubevirt-hyperconverged
+    spec: {}
+    EOF
+    ```
 
-- Uninstall the HCO. If the uninstall process continues to run, you must
+  * In versions earlier than <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->,
+    use the `v1beta1` API version:
+    ```bash
+    $ cat <<EOF | kubectl apply -f -
+    apiVersion: hco.kubevirt.io/v1beta1
+    kind: HyperConverged
+    metadata:
+      name: kubevirt-hyperconverged
+      namespace: kubevirt-hyperconverged
+    spec: {}
+    EOF
+    ```
+
+- Uninstall the HCO. If the uninstallation process continues to run, you must
 resolve that issue in order to cancel the alert.

--- a/docs/runbooks/HCOMultiArchGoldenImagesDisabled.md
+++ b/docs/runbooks/HCOMultiArchGoldenImagesDisabled.md
@@ -8,17 +8,15 @@ and then used to create VM boot disks with a specific operating system.
 By default, the preloaded images use the architecture of the cluster node that
 was used to create the image.
 
-If the `enableMultiArchBootImageImport` feature gate is enabled in the
-HyperConverged custom resource (CR), multiple preloaded images are created for
-each DataImportCronTemplate (DICT), one for each architecture supported by the
-cluster and by the original image.
+If the multi-architecture feature is enabled, multiple preloaded
+images are created for each DataImportCronTemplate (DICT), one for each
+architecture supported by the cluster and by the original image.
 
 This allows the VMs to be scheduled on nodes with the same architecture as the
 preloaded image.
 
 This alert is triggered when running on a heterogeneous cluster (a cluster with
-nodes of different architectures) while the `enableMultiArchBootImageImport`
-feature gate is disabled in the HyperConverged CR.
+nodes of different architectures) while the multi-architecture feature is disabled.
 
 ## Impact
 
@@ -29,10 +27,15 @@ the VM fails to start.
 ## Diagnosis
 
 HCO checks the workload node architectures in the cluster. By default, HCO
-considers the worker nodes as the workload nodes. If the
-`spec.workloads.nodePlacement` field in the HyperConverged CR is populated,
-HCO considers the nodes that match the node selector in this field as the
-workload nodes.
+considers the worker nodes as the workload nodes. If the workload node
+placement is configured, HCO considers the nodes that match the node selector
+in this field as the workload nodes.
+
+> **Note**:
+> * In version <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->
+  or above, the workload configuration is under `spec.deployment.nodePlacements.workload`
+> * In versions earlier than <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->,
+    the workload configuration is under `spec.workloads.nodePlacement`
 
 HCO publishes the list of the workload node architectures in the
 `status.nodeInfo.workloadsArchitectures` field in the HyperConverged CR.
@@ -43,83 +46,113 @@ Read the HyperConverged CR:
 $ kubectl get hyperconverged -n kubevirt-hyperconverged kubevirt-hyperconverged -o yaml
 ```
 
-The result looks similar to this:
+* In version <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->
+  or above, the result looks similar to this:
+  ```yaml
+  apiVersion: hco.kubevirt.io/v1
+  kind: HyperConverged
+  spec:
+    ...
+    deployment:
+      nodePlacements:
+        workload: # check if the spec.deployment.nodePlacements.workload field is populated
+    ...
+  status:
+    ...
+    nodeInfo:
+      workloadsArchitectures:
+        - amd64
+        - arm64
+  ...
+  ```
 
-```yaml
-apiVersion: hco.kubevirt.io/v1beta1
-kind: HyperConverged
-spec:
+* In versions earlier than <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->, the result
+  looks similar to this:
+  ```yaml
+  apiVersion: hco.kubevirt.io/v1beta1
+  kind: HyperConverged
+  spec:
+    ...
+    workloads: # check if the spec.workloads.nodePlacement field is populated
+      nodePlacement:
+    ...
+  status:
+    ...
+    nodeInfo:
+      workloadsArchitectures:
+        - amd64
+        - arm64
   ...
-  workloads: # check if the spec.workloads.nodePlacement field is populated
-    nodePlacement:
-  ...
-status:
-  ...
-  nodeInfo:
-    workloadsArchitectures:
-      - amd64
-      - arm64
-...
-```
+  ```
 
 ## Mitigation
 
-To address this issue, you can either enable the multi-arch boot image feature,
-or modify the workloads node placement in the HyperConverged CR to include only
-nodes with a single architecture.
+To address this issue, you can either enable the multi-architecture boot image
+feature, or modify the workloads node placement in the HyperConverged CR to
+include only nodes with a single architecture.
 
-### Enable the multi-arch boot image feature
+### Enable the multi-architecture boot image feature
 
-The multi-arch boot image feature is in the alpha stage, and it is not enabled
-by default. Enabling this feature results in the creation of multiple
-preloaded images for each DataImportCronTemplate (DICT), one for each
-architecture supported by the cluster, and by the original image. However, this
-feature is not generally available, and it is not fully supported.
+The multi-architecture boot image feature is not enabled by default. Enabling
+this feature results in the creation of multiple preloaded images for each
+DataImportCronTemplate (DICT), one for each architecture supported by the
+cluster, and by the original image. However, this feature is not generally
+available, and it is not fully supported.
 
-To enable the multi-arch boot image feature:
+Enablement of the multi-architecture boot image feature:
 
-1. Set the `enableMultiArchBootImageImport` feature gate in the
-   HyperConverged CR to `true`.
-
-2. If the HyperConverged CR contains the `spec.dataImportCronTemplates` field,
+* Enable the multi-architecture boot image feature
+* If the HyperConverged CR contains the `dataImportCronTemplates` field,
 and this field is not empty, then you might need to add the
 `ssp.kubevirt.io/dict.architectures` annotation to each DICT object in this
-field. See
-the [HCOGoldenImageWithNoArchitectureAnnotation](HCOGoldenImageWithNoArchitectureAnnotation.md)
+field. See the [HCOGoldenImageWithNoArchitectureAnnotation](HCOGoldenImageWithNoArchitectureAnnotation.md)
 runbook for more details.
 
-3. Edit the HyperConverged CR:
+1. open the editor to edit the `HyperConverged` CR:
+   ```shell
+   $ NAMESPACE="$(kubectl get hyperconverged -A --no-headers | awk '{print $1}')"
+   $ kubectl edit hyperconverged -n "${NAMESPACE}" kubevirt-hyperconverged -o yaml
+   ```
 
-    ```bash
-    $ kubectl edit hyperconverged -n kubevirt-hyperconverged kubevirt-hyperconverged -o yaml
-    ```
-
-    The editor opens with the HyperConverged CR YAML.
-
-4. Edit the CR to set the `enableMultiArchBootImageImport` feature gate to `true`,
-and to add the `ssp.kubevirt.io/dict.architectures` annotation to each DICT
-object in the `spec.dataImportCronTemplates` field, if needed.
-
-    ```yaml
-    apiVersion: hco.kubevirt.io/v1beta1
-    kind: HyperConverged
-    spec:
-      dataImportCronTemplates:
+   The editor opens with the HyperConverged CR YAML.
+2. Edit the CR:
+   * In version <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0--> or above, use the `v1` API
+     version:
+      ```yaml
+      apiVersion: hco.kubevirt.io/v1
+      kind: HyperConverged
+      spec:
         ...
-      ...
-      featureGates:
+        workloadSources:
+          enableMultiArchBootImageImport: true
+          dataImportCronTemplates:
+            ...
         ...
-        enableMultiArchBootImageImport: true
-        ...
-    ```
-
-5. Save the changes and exit the editor.
+      ```
+   * In versions earlier than <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->, use the
+     `v1beta1` API version:
+       ```yaml
+       apiVersion: hco.kubevirt.io/v1beta1
+       kind: HyperConverged
+       spec:
+         dataImportCronTemplates:
+           ...
+         ...
+         featureGates:
+           ...
+           enableMultiArchBootImageImport: true
+           ...
+       ```
+3. Save the changes and exit the editor, to apply the changes.
 
 ### Modify the Workloads Node Placement
 
-If you do not want to enable the multi arch boot image feature, you can modify
-the workloads node placement in the HyperConverged CR to include only nodes with
-a single architecture.
+If you do not want to enable the multi-architecture boot image feature, you can
+modify the workloads node placement in the HyperConverged CR to include only
+nodes with a single architecture.
+
+Below is an example of how to modify the workloads node placement to include
+only nodes with the `amd64` architecture, using node affinity:
 
 1. Edit the HyperConverged CR:
     ```bash
@@ -128,9 +161,30 @@ a single architecture.
 
     The editor opens with the HyperConverged CR YAML.
 
-    Below is an example of how to modify the workloads node placement to include
-only nodes with the `amd64` architecture, using node affinity:
-
+2. Edit the CR:
+    * In version <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0--> or above, use the `v1` API
+      version:
+    ```yaml
+    apiVersion: hco.kubevirt.io/v1
+    kind: HyperConverged
+    spec:
+      ...
+      deployment:
+        nodePlacements:
+          workload:
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: kubernetes.io/arch
+                          operator: In
+                          values:
+                            - amd64
+      ...
+    ```
+   * In versions earlier than <!--USstart-->`v1.19.0`<!--USend--><!--DS: v4.23.0-->, use the
+     `v1beta1` API version:
     ```yaml
     apiVersion: hco.kubevirt.io/v1beta1
     kind: HyperConverged
@@ -150,7 +204,7 @@ only nodes with the `amd64` architecture, using node affinity:
       ...
     ```
 
-2. Save the changes and exit the editor.
+3. Save the changes and exit the editor, to apply the changes.
 
 <!--USstart-->
 If you cannot resolve the issue, see the following resources:


### PR DESCRIPTION
**What this PR does / why we need it**:

Modify all the runbooks' instructions and the examples that read or manipulate the `HyperConverged` CR, to also include the `v1` API version.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
