### PR TITLE
Add virt-platform-autopilot alert runbooks

### DIFF
--- a/docs/runbooks/VirtPlatformAutopilotDependencyMissing.md
+++ b/docs/runbooks/VirtPlatformAutopilotDependencyMissing.md
@@ -1,0 +1,76 @@
+# VirtPlatformAutopilotDependencyMissing
+
+## Meaning
+
+This alert fires when virt-platform-autopilot detects that an optional CRD it
+would use (a soft dependency) is missing from the cluster.
+
+The alert is driven by the `kubevirt_autopilot_missing_dependency` gauge,
+labelled by `group`, `version`, and `kind`:
+
+- `1` = the CRD is absent
+- `0` = the CRD is present
+
+The alert triggers on `kubevirt_autopilot_missing_dependency == 1` held for
+`5m`. When a soft-dependency CRD is missing, the operator skips the assets that
+require it and continues to manage everything else ("inform, don't crash").
+
+## Impact
+
+This is a `warning` alert. The cluster remains functional but is
+feature-incomplete: the platform features that rely on the missing CRD (for
+example, load-aware scheduling when the descheduler CRD is absent) are not
+configured until the CRD is installed.
+
+## Diagnosis
+
+1. Read the `group`, `version`, and `kind` of the missing CRD from the alert
+   labels.
+
+2. Confirm the CRD is absent. Substitute the `kind` from the alert labels
+   below. CRD names use the plural form (which cannot be derived
+   deterministically), so this searches by the kind suffix:
+
+   ```bash
+   $ kubectl get crd -o name | grep -i '<kind>'
+   ```
+
+3. Decide whether the CRD is expected on this cluster. If it should be present,
+   check the health of the operator that provides it. Replace `<provider-operator>`
+   with the actual operator name (e.g., `descheduler` for the Kube Descheduler Operator):
+
+   ```bash
+   $ kubectl get csv -A | grep -i <provider-operator>
+   ```
+
+## Mitigation
+
+- **The feature is wanted:** install the operator that provides the CRD. For
+  example, to enable load-aware scheduling install the Kube Descheduler
+  Operator. First discover the operator package in the catalog:
+
+  ```bash
+  $ kubectl get packagemanifests -n openshift-marketplace | \
+      grep cluster-kube-descheduler-operator
+  ```
+
+  Then install it from OperatorHub or by creating an OLM `Subscription` for the
+  package; follow the operator's own documentation for the exact install steps.
+
+  virt-platform-autopilot detects the CRD automatically once it appears and
+  resumes managing the dependent assets. The alert resolves within a few
+  minutes of `kubevirt_autopilot_missing_dependency` returning to `0`.
+
+- **The feature is intentionally not installed** (for example, a development
+  cluster): the alert is informational and safe to silence in Alertmanager. It
+  does not affect any other platform functionality.
+
+<!--DS: If you cannot resolve the issue, log in to the
+link:https://access.redhat.com[Customer Portal] and open a support case,
+attaching the artifacts gathered during the diagnosis procedure.-->
+<!--USstart-->
+If you cannot resolve the issue, see the following resources:
+
+- [OKD Help](https://okd.io/docs/community/help)
+- [#virtualization Slack channel](https://kubernetes.slack.com/channels/virtualization)
+<!--USend-->

--- a/docs/runbooks/VirtPlatformAutopilotSyncFailed.md
+++ b/docs/runbooks/VirtPlatformAutopilotSyncFailed.md
@@ -1,0 +1,117 @@
+# VirtPlatformAutopilotSyncFailed
+
+## Meaning
+
+This alert fires when virt-platform-autopilot fails to apply its desired
+configuration (the "Opinionated State") to a managed resource for at least 15
+minutes.
+
+The alert is driven by the `kubevirt_autopilot_compliance_status` gauge, which
+is set per managed resource (labelled by `kind`, `name`, and `namespace`):
+
+- `1` = synced (the live resource matches the Golden State)
+- `0` = drifted or the last apply failed
+
+The alert triggers on `kubevirt_autopilot_compliance_status == 0` held for
+`15m`. The delay tolerates transient API errors and slow rollouts; if the
+condition persists longer, the automation is genuinely stuck and needs
+attention.
+
+## Impact
+
+This is a `critical` alert. The affected resource is not in its desired state
+and virt-platform-autopilot cannot correct the drift on its own. Platform
+features that depend on the resource may be degraded or unavailable until the
+condition clears.
+
+## Diagnosis
+
+1. Export the `NAMESPACE` environment variable:
+
+   ```bash
+   $ export NAMESPACE="$(kubectl get deployment virt-platform-autopilot -A \
+       -o custom-columns="":.metadata.namespace | tr -d '[:space:]')"
+   ```
+
+2. Read the `kind`, `name`, and `namespace` of the affected resource from the
+   alert labels.
+
+3. Inspect the operator logs for errors relating to that resource:
+
+   ```bash
+   $ kubectl -n $NAMESPACE logs --tail=-1 -l app=virt-platform-autopilot | \
+       grep -iE "forbidden|admission|webhook|conflict|not found|failed to apply"
+   ```
+
+4. Inspect the affected resource and its recent events. For namespaced resources:
+
+   ```bash
+   $ kubectl get <kind> <name> -n <namespace> -o yaml
+   $ kubectl get events -n <namespace> \
+       --field-selector involvedObject.kind=<kind>,involvedObject.name=<name>
+   ```
+
+   For cluster-scoped resources like `KubeDescheduler` or `MachineConfig`, omit
+   `-n <namespace>` and use `-A` for events:
+
+   ```bash
+   $ kubectl get <kind> <name> -o yaml
+   $ kubectl get events -A \
+       --field-selector involvedObject.kind=<kind>,involvedObject.name=<name>
+   ```
+
+## Mitigation
+
+Resolve the root cause revealed by the logs and events:
+
+- **Admission webhook rejection:** fix the policy, or exempt the operator
+  service account `system:serviceaccount:$NAMESPACE:virt-platform-autopilot`.
+- **RBAC denial:** this indicates a bug in the virt-platform-autopilot
+  installation. The operator should have the required permissions by default.
+  Report this issue with the output of:
+
+  ```bash
+  $ kubectl auth can-i update <resource-type> -n <namespace> \
+      --as system:serviceaccount:$NAMESPACE:virt-platform-autopilot
+  $ kubectl get clusterrolebinding virt-platform-autopilot-rolebinding
+  ```
+
+- **Conflicting controller or user (edit war):** see
+  [VirtPlatformAutopilotThrashingDetected](VirtPlatformAutopilotThrashingDetected.md).
+- **Missing CRD:** see
+  [VirtPlatformAutopilotDependencyMissing](VirtPlatformAutopilotDependencyMissing.md).
+
+If the drift is intentional and the resource must be managed outside of
+virt-platform-autopilot, stop the automation for it:
+
+```bash
+$ kubectl annotate <kind> <name> -n <namespace> \
+    platform.kubevirt.io/mode=unmanaged --overwrite
+```
+
+If the operator appears stuck, restart it to force a fresh reconcile:
+
+```bash
+$ kubectl -n $NAMESPACE rollout restart deployment virt-platform-autopilot
+```
+
+Verify the rollout completes:
+
+```bash
+$ kubectl -n $NAMESPACE rollout status deployment virt-platform-autopilot
+```
+
+The alert resolves when `kubevirt_autopilot_compliance_status` is no longer `0`
+for the affected resource: either it returns to `1` (synced), or the compliance
+series is removed entirely (the resource is now unmanaged or excluded from
+autopilot control).
+
+<!--DS: If you cannot resolve the issue, log in to the
+link:https://access.redhat.com[Customer Portal] and open a support case,
+attaching the artifacts gathered during the diagnosis procedure.-->
+<!--USstart-->
+If you cannot resolve the issue, see the following resources:
+
+- [OKD Help](https://okd.io/docs/community/help)
+- [#virtualization Slack channel](https://kubernetes.slack.com/channels/virtualization)
+<!--USend-->

--- a/docs/runbooks/VirtPlatformAutopilotThrashingDetected.md
+++ b/docs/runbooks/VirtPlatformAutopilotThrashingDetected.md
@@ -1,0 +1,112 @@
+# VirtPlatformAutopilotThrashingDetected
+
+## Meaning
+
+This alert fires when virt-platform-autopilot detects an "edit war" on a
+managed resource and pauses its reconciliation to protect the API server.
+
+An edit war happens when another controller or a user repeatedly modifies a
+resource that virt-platform-autopilot manages, so each apply is immediately
+overwritten. When this is detected, the operator sets the
+`platform.kubevirt.io/reconcile-paused=true` annotation on the resource and
+stops reconciling it.
+
+The alert is driven by the `kubevirt_autopilot_paused_resources` gauge,
+labelled by `kind`, `name`, and `namespace`:
+
+- `1` = reconciliation paused for the resource
+- `0` = reconciliation active
+
+The alert triggers immediately on `kubevirt_autopilot_paused_resources > 0`
+(there is no `for` clause). The related `kubevirt_autopilot_thrashing_total`
+counter tracks the anti-thrashing gate hits that lead up to a pause.
+
+## Impact
+
+This is a `warning` alert. While a resource is paused, its drift is no longer
+corrected and it may diverge from the desired state. This is a deliberate
+safety mechanism that prevents a reconciliation loop from overloading the API
+server; the operator itself is healthy.
+
+## Diagnosis
+
+1. Export the `NAMESPACE` environment variable:
+
+   ```bash
+   $ export NAMESPACE="$(kubectl get deployment virt-platform-autopilot -A \
+       -o custom-columns="":.metadata.namespace | tr -d '[:space:]')"
+   ```
+
+2. Read the `kind`, `name`, and `namespace` of the paused resource from the
+   alert labels. Replace `<kind>`, `<name>`, and `<namespace>` with the
+   corresponding alert-label values in all commands below. Confirm the pause
+   annotation is set:
+
+   ```bash
+   $ kubectl get <kind> <name> -n <namespace> \
+       -o jsonpath='{.metadata.annotations.platform\.kubevirt\.io/reconcile-paused}'
+   ```
+
+3. Identify the competing writer. As a best-effort check, inspect the
+   resource's `managedFields`: the operator applies with the field manager
+   `virt-platform-autopilot`, so any other manager is a likely source of the
+   conflict:
+
+   ```bash
+   $ kubectl get <kind> <name> -n <namespace> \
+       -o jsonpath='{.metadata.managedFields[*].manager}'
+   ```
+
+   For an authoritative record of who wrote the resource, consult the API
+   server audit log (where audit logging is enabled).
+
+## Mitigation
+
+Choose the option that matches the intent:
+
+- **The external change is unintentional:** stop or fix the conflicting
+  controller or workflow, then resume reconciliation by removing the pause
+  annotation:
+
+  ```bash
+  $ kubectl annotate <kind> <name> -n <namespace> \
+      platform.kubevirt.io/reconcile-paused-
+  ```
+
+- **The external change is intentional** (another tool should own the
+  resource): transfer ownership so the operator stops managing it:
+
+  ```bash
+  $ kubectl annotate <kind> <name> -n <namespace> \
+      platform.kubevirt.io/mode=unmanaged --overwrite
+  ```
+
+- **Only specific fields conflict:** keep the resource managed but carve out
+  the contested fields, using either a JSON Patch override or an ignore list:
+
+  ```bash
+  $ kubectl annotate <kind> <name> -n <namespace> \
+      platform.kubevirt.io/patch='[{"op":"replace","path":"/spec/yourField","value":"yourValue"}]' \
+      --overwrite
+
+  $ kubectl annotate <kind> <name> -n <namespace> \
+      platform.kubevirt.io/ignore-fields='/spec/replicas' --overwrite
+  ```
+
+  The `patch` annotation uses RFC 6902 JSON Patch array format. The
+  `ignore-fields` annotation uses comma-separated RFC 6901 JSON Pointer paths
+  (e.g., `/spec/replicas,/metadata/labels/app`).
+
+The alert resolves when `kubevirt_autopilot_paused_resources` returns to `0`,
+which happens once the pause annotation is removed and no further conflict is
+detected.
+
+<!--DS: If you cannot resolve the issue, log in to the
+link:https://access.redhat.com[Customer Portal] and open a support case,
+attaching the artifacts gathered during the diagnosis procedure.-->
+<!--USstart-->
+If you cannot resolve the issue, see the following resources:
+
+- [OKD Help](https://okd.io/docs/community/help)
+- [#virtualization Slack channel](https://kubernetes.slack.com/channels/virtualization)
+<!--USend-->

--- a/docs/runbooks/VirtPlatformAutopilotTombstoneStuck.md
+++ b/docs/runbooks/VirtPlatformAutopilotTombstoneStuck.md
@@ -1,0 +1,124 @@
+# VirtPlatformAutopilotTombstoneStuck
+
+## Meaning
+
+This alert fires when virt-platform-autopilot cannot remove a resource it is
+trying to delete (a "tombstone") for more than 30 minutes, either because
+deletion failed (`-1`) or because the resource lacks the required management
+label (`-2`).
+
+The alert is driven by the `kubevirt_autopilot_tombstone_status` gauge,
+labelled by `kind`, `name`, and `namespace`:
+
+- `1` = the resource still exists (deletion pending)
+- `0` = the resource is deleted or the CRD is absent
+- `-1` = deletion error (an API error, finalizer, webhook, or RBAC blocks it)
+- `-2` = skipped due to a label mismatch (the resource lacks the
+  `platform.kubevirt.io/managed-by=virt-platform-autopilot` label)
+
+The alert triggers on `kubevirt_autopilot_tombstone_status < 0` held for `30m`.
+
+## Impact
+
+This is a `warning` alert. The impact depends on the firing condition:
+
+- **Deletion error (`-1`):** an obsolete resource lingers in the cluster but is
+  not actively used. Over time, accumulated tombstones cause configuration drift
+  and can conflict with a resource later recreated under the same name.
+- **Label mismatch (`-2`):** the resource may be an active user-owned resource
+  that the operator refuses to delete as a safety mechanism. This is not stale
+  cleanup: verify ownership before treating it as a tombstone.
+
+## Diagnosis
+
+1. Export the `NAMESPACE` environment variable:
+
+   ```bash
+   $ NAMESPACE="$(kubectl get deployment -A -l app=virt-platform-autopilot \
+       -o jsonpath='{.items[*].metadata.namespace}')"
+   $ [ "$(echo "$NAMESPACE" | wc -w)" -eq 1 ] || \
+       { echo "Error: expected 1 deployment, found in: ${NAMESPACE:-none}"; exit 1; }
+   $ export NAMESPACE
+   ```
+
+2. Read the `kind`, `name`, and `namespace` from the alert labels, and note
+   the metric value: `-1` (deletion error) or `-2` (label mismatch).
+
+3. For a **deletion error (`-1`)**, check what is blocking removal as stuck
+   finalizers, an in-progress deletion, RBAC, and the operator logs:
+
+   ```bash
+   $ kubectl get <kind> <name> -n <namespace> \
+       -o jsonpath='{.metadata.finalizers} {.metadata.deletionTimestamp}'
+   $ kubectl auth can-i get <resource-type> -n <namespace> \
+       --as system:serviceaccount:$NAMESPACE:virt-platform-autopilot
+   $ kubectl auth can-i delete <resource-type> -n <namespace> \
+       --as system:serviceaccount:$NAMESPACE:virt-platform-autopilot
+   $ kubectl -n $NAMESPACE logs --tail=200 \
+       -l app=virt-platform-autopilot | grep -i tombstone
+   ```
+
+   Replace `<resource-type>` with the lowercased, pluralized form of `<kind>`
+   (e.g., `services`, `configmaps`). For CRDs, use the format shown by
+   `kubectl api-resources` (e.g., `kubedeschedulers`, `machineconfigs`). Omit
+   `-n <namespace>` for cluster-scoped resources like `KubeDescheduler` or
+   `MachineConfig`.
+
+4. For a **label mismatch (`-2`)**, confirm the resource lacks the management
+   label. This is the safety check working as intended: the operator refuses to
+   delete a resource it did not create. Omit `-n <namespace>` for cluster-scoped
+   resources like `KubeDescheduler` or `MachineConfig`.
+
+   ```bash
+   $ kubectl get <kind> <name> -n <namespace> \
+       -o jsonpath='{.metadata.labels.platform\.kubevirt\.io/managed-by}'
+   ```
+
+## Mitigation
+
+- **Deletion error (`-1`):** clear the blocker. Remove a finalizer left behind
+  by a dead controller, fix or bypass the blocking webhook, or restore the
+  operator's delete permissions. The operator retries deletion on every
+  reconcile, so no manual delete is needed once the blocker is gone:
+
+  Inspect the finalizers first (see the Diagnosis step) and confirm the one
+  you intend to clear is stale, left by a controller that no longer exists and
+  whose cleanup is already done. Then remove only that finalizer by its index,
+  leaving any others in place. Use a test operation to verify the expected
+  finalizer is still at that index:
+
+  ```bash
+  $ kubectl patch <kind> <name> -n <namespace> --type=json \
+      -p='[{"op":"test","path":"/metadata/finalizers/<index>","value":"<expected-finalizer>"},
+          {"op":"remove","path":"/metadata/finalizers/<index>"}]'
+  ```
+
+  The patch will fail if the finalizer array changed since inspection — if that
+  happens, re-inspect and adjust the index. Removing a live finalizer skips the
+  cleanup it guards, so only do this when you understand the consequences.
+
+- **Label mismatch (`-2`):** if the resource should be removed by the operator,
+  add the management label so the next reconcile deletes it. Otherwise, the
+  resource is owned by someone else and must be handled manually. Omit
+  `-n <namespace>` for cluster-scoped resources like `KubeDescheduler` or
+  `MachineConfig`.
+
+  ```bash
+  $ kubectl label <kind> <name> -n <namespace> \
+      platform.kubevirt.io/managed-by=virt-platform-autopilot
+  ```
+
+The `for: 30m` clause only delays firing; it does not delay resolution. The
+alert clears on the next evaluation after the expression becomes false, that
+is, once `kubevirt_autopilot_tombstone_status` is no longer negative (the
+resource is deleted or the CRD is absent, `0`, or exists again, `1`).
+
+<!--DS: If you cannot resolve the issue, log in to the
+link:https://access.redhat.com[Customer Portal] and open a support case,
+attaching the artifacts gathered during the diagnosis procedure.-->
+<!--USstart-->
+If you cannot resolve the issue, see the following resources:
+
+- [OKD Help](https://okd.io/docs/community/help)
+- [#virtualization Slack channel](https://kubernetes.slack.com/channels/virtualization)
+<!--USend-->


### PR DESCRIPTION

**What this PR does / why we need it**:
Add runbooks for the four virt-platform-autopilot operator alerts:

- `VirtPlatformAutopilotSyncFailed` (critical)
- `VirtPlatformAutopilotThrashingDetected` (warning)
- `VirtPlatformAutopilotDependencyMissing` (warning)
- `VirtPlatformAutopilotTombstoneStuck` (warning)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [#](https://redhat.atlassian.net/browse/CNV-96023)

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add virt-platform-autopilot alert runbooks
```
